### PR TITLE
Fix: write AHK templates

### DIFF
--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -23,7 +23,7 @@ public class Game
     /// The game only takes in a directory handed down by the Playlist class, it then finds all the relevant information for the Game
     /// </summary>
     /// <param name="directory">The directory path.</param>
-    public Game(string directory) 
+    public Game(string directory)
 	{
 		this.directory = new DirectoryInfo (directory);
 
@@ -61,14 +61,14 @@ public class Game
     /// </summary>
 	private void BuildGameJSON()
 	{
-		var J = GM.data.LoadJson (directory.FullName + "\\winnitron_metadata.json");
+		var J = GM.data.LoadJson (directory.FullName + "/winnitron_metadata.json");
 
 		this.name = J ["title"];
 		this.author = null; //No author stuff just yet
 		this.screenshot = GetScreenshot();
-		this.executable = Path.Combine(directory.FullName + "\\", J["executable"]);
+		this.executable = Path.Combine(directory.FullName + "/", J["executable"]);
 
-        switch(J["template"])
+        switch(J["keys"]["template"])
         {
             case "default":
                 gameType = GameType.EXE;
@@ -148,7 +148,7 @@ public class Game
     private bool DetermineGameType()
     {
         if (Directory.GetFiles(this.directory.ToString(), "*.html").Length == 1)
-        {       
+        {
             executable = Directory.GetFiles(this.directory.ToString(), "*.html")[0];
             Debug.Log("Determined PICO8! " + executable);
             gameType = GameType.PICO8;
@@ -182,7 +182,7 @@ public class Game
             case Game.GameType.EXE:
 
                 newAHKfile = Resources.Load<TextAsset>("AHK_templates/ExeGameTemplate").text;
-            
+
                 newAHKfile = newAHKfile.Replace("{GAME_PATH}", executable);
                 newAHKfile = newAHKfile.Replace("{GAME_NAME}", name);
 

--- a/Assets/Scripts/System/GameSync.cs
+++ b/Assets/Scripts/System/GameSync.cs
@@ -354,10 +354,9 @@ public class GameSync : MonoBehaviour {
             installationMetadata.Add("image_url", new JSONData(imageURL));
 
 
-			Debug.Log( "JSON: " + title + "/" + keyTemplate);
-			JSONClass keymap = new JSONClass();
-			keymap.Add("template", new JSONData(keyTemplate));
-			installationMetadata.Add("keys", keymap);
+            JSONClass keymap = new JSONClass();
+            keymap.Add("template", new JSONData(keyTemplate));
+            installationMetadata.Add("keys", keymap);
 
             string filename = installDirectory + "/winnitron_metadata.json";
             Debug.Log("writing to " + filename + ": " + installationMetadata.ToString());

--- a/Assets/Scripts/System/GameSync.cs
+++ b/Assets/Scripts/System/GameSync.cs
@@ -57,7 +57,7 @@ public class GameSync : MonoBehaviour {
     /// </summary>
     public void execute()
     {
-        if (syncType != SyncType.NONE)
+        if (true) // syncType != SyncType.NONE)
         {
             GM.dbug.Log(this, "GameSync: Running Sync...");
             SyncText("INITIALIZING SYNC!");
@@ -217,7 +217,7 @@ public class GameSync : MonoBehaviour {
 
 
 
-    /// 
+    ///
     /// DATA STRUCTURES FOR SYNCING
     ///
 
@@ -310,7 +310,7 @@ public class GameSync : MonoBehaviour {
         public int minPlayers;
         public int maxPlayers;
         public string executable;
-        public bool legacyControls;
+        public string keyTemplate;
 
         public JSONNode installationMetadata;
 
@@ -324,8 +324,9 @@ public class GameSync : MonoBehaviour {
             minPlayers = data["min_players"].AsInt;
             maxPlayers = data["max_players"].AsInt;
             executable = data["executable"];
-            legacyControls = data["legacy_controls"].AsBool;
             imageURL = data["image_url"];
+            keyTemplate = data["keys"]["template"];
+
 
             if (alreadyInstalled()) {
                 string json = File.ReadAllText(installDirectory + "winnitron_metadata.json");
@@ -350,8 +351,13 @@ public class GameSync : MonoBehaviour {
             installationMetadata.Add("min_players", new JSONData(minPlayers));
             installationMetadata.Add("max_players", new JSONData(maxPlayers));
             installationMetadata.Add("executable", new JSONData(executable));
-            installationMetadata.Add("legacy_controls", new JSONData(legacyControls));
             installationMetadata.Add("image_url", new JSONData(imageURL));
+
+
+			Debug.Log( "JSON: " + title + "/" + keyTemplate);
+			JSONClass keymap = new JSONClass();
+			keymap.Add("template", new JSONData(keyTemplate));
+			installationMetadata.Add("keys", keymap);
 
             string filename = installDirectory + "/winnitron_metadata.json";
             Debug.Log("writing to " + filename + ": " + installationMetadata.ToString());


### PR DESCRIPTION
AHK templates weren't being written properly because of a mismatch between API changes and the sync. This shit ain't why we `stable` I guess ¯\\\_(ツ)_/¯

@mrmwiebe 