### PR TITLE
Improve AHK script(s)

### DIFF
--- a/Assets/Options/RunGame.ahk
+++ b/Assets/Options/RunGame.ahk
@@ -2,32 +2,53 @@
 
 #Persistent
 #MaxHotkeysPerInterval 200
+#SingleInstance Force
 
+debug := true
+
+executable := "C:\WINNITRON_UserData\Playlists\official-winnitron\nidhogg\Nidhogg.exe"
+forceQuitHoldTime := 3000
+idleLimit := 30000
+initialWait := 30000
+
+start := SecondsToday()
+WriteLog("START ---------------- " . A_Now)
 
 ; RUN THE GAME
-Run, C:\WINNITRON_UserData\Playlists\official-winnitron\nidhogg\Nidhogg.exe, , , process_pid
-idleLimit:= 10000 ; three seconds
-SetTimer, InitialWait, 30000
+Run, %executable%, , , process_pid
+WriteLog("Launched " . executable . " with pid " . process_pid)
+
+SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
 MouseMove 3000, 3000, 0
 
-; This is the function that quits the app
+; This is the function that quits the game
 KillApp()
 {
-	WinKill, ahk_exe C:\WINNITRON_UserData\Playlists\official-winnitron\nidhogg\Nidhogg.exe	; Tries to close using .exe
+	global process_pid
+
+	WriteLog("Killing app with pid " . process_pid)
+	WinKill, ahk_exe %executable%	; Tries to close using .exe
 	WinKill, ahk_pid process_pid	; Tries to close using process id
 	SetTitleMatchMode, 2
 	WinKill, Nidhogg			; Tries to close hoping that part of the game name is in the title
 	ExitApp
 }
 
+; Do this so we don't keep running through InitialWait and CloseOnIdle
+Loop
+{
+}
+
 InitialWait:
+	WriteLog("Completed initial wait")
 	SetTimer,  CloseOnIdle, % idleLimit+150
 return
 
 ; This is the timer
 CloseOnIdle:
-	if (A_TimeIdle>=idleLimit)
+	if (A_TimeIdle >= idleLimit)
 	{
+		WriteLog("Idle timeout!")
 		KillApp()
 		SetTimer,CloseOnIdle, Off
 	}
@@ -39,10 +60,11 @@ return
 
 ; Do this stuff when Esc is pressed
 ~Esc::
+	WriteLog("ESC pressed")
 	If escIsPressed
 		return
 	escIsPressed := true
-	SetTimer, WaitForESCRelease, 3000		; 3 seconds
+	SetTimer, WaitForESCRelease, %forceQuitHoldTime%
 return
 
 ; Do this stuff when Esc is UP
@@ -55,5 +77,29 @@ WaitForESCRelease:
 	SetTimer, WaitForESCRelease, Off
 	KillApp()
 return
+
+
+; DEBUGGING STUFF
+
+; Number of seconds since midnight.
+SecondsToday() {
+	return A_Hour * 3600 + A_Min * 60 + A_Sec
+}
+
+WriteLog(message)
+{
+	global debug
+	global start
+
+	if (debug) {
+		runningTimeSec := SecondsToday() - start
+		debugLog := "ahk_output.txt"
+		FileAppend,
+		(
+		%runningTimeSec%s %A_Tab% %message%
+
+		), %debugLog%, UTF-8
+	}
+}
 
 ; KEYMAPS BELOW (NONE IN DEFAULT SCRIPT)

--- a/Assets/Resources/AHK_templates/ExeGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/ExeGameTemplate.txt
@@ -2,58 +2,105 @@
 
 #Persistent
 #MaxHotkeysPerInterval 200
+#SingleInstance Force
 
+debug := {DEBUG_OUTPUT}
+
+executable := "{GAME_PATH}"
+game_name := "{GAME_NAME}"
+forceQuitHoldTime := {ESC_HOLD}000
+idleLimit := {IDLE_TIME}000
+initialWait := {IDLE_INITIAL}000
+
+start := SecondsToday()
+WriteLog("START ---------------- " . A_Now)
 
 ; RUN THE GAME
-Run, {GAME_PATH}, , , process_pid
-idleLimit:= {IDLE_TIME}000 ; three seconds
-SetTimer, InitialWait, {IDLE_INITIAL}000
+Run, %executable%, , , process_pid
+WriteLog("Launched " . executable . " with pid " . process_pid)
+
+SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
 MouseMove 3000, 3000, 0
 
-; This is the function that quits the app
+; This is the function that quits the game
 KillApp()
 {
-	WinKill, ahk_exe {GAME_PATH}	; Tries to close using .exe
-	WinKill, ahk_pid process_pid	; Tries to close using process id
-	SetTitleMatchMode, 2
-	WinKill, {GAME_NAME}			; Tries to close hoping that part of the game name is in the title
-	ExitApp
+  global process_pid
+
+  WriteLog("Killing app with pid " . process_pid)
+  WinKill, ahk_exe %executable% ; Tries to close using .exe
+  WinKill, ahk_pid process_pid  ; Tries to close using process id
+  SetTitleMatchMode, 2
+  WinKill, Nidhogg      ; Tries to close hoping that part of the game name is in the title
+  ExitApp
+}
+
+; Do this so we don't keep running through InitialWait and CloseOnIdle
+Loop
+{
 }
 
 InitialWait:
-	SetTimer,  CloseOnIdle, % idleLimit+150
+  WriteLog("Completed initial wait")
+  SetTimer,  CloseOnIdle, % idleLimit+150
 return
 
 ; This is the timer
 CloseOnIdle:
-	if (A_TimeIdle>=idleLimit)
-	{
-		KillApp()
-		SetTimer,CloseOnIdle, Off
-	}
-	else
-	{
-		SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
-	}
+  if (A_TimeIdle >= idleLimit)
+  {
+    WriteLog("Idle timeout!")
+    KillApp()
+    SetTimer,CloseOnIdle, Off
+  }
+  else
+  {
+    SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
+  }
 return
 
 ; Do this stuff when Esc is pressed
 ~Esc::
-	If escIsPressed
-		return
-	escIsPressed := true
-	SetTimer, WaitForESCRelease, {ESC_HOLD}000		; 3 seconds
+  WriteLog("ESC pressed")
+  If escIsPressed
+    return
+  escIsPressed := true
+  SetTimer, WaitForESCRelease, %forceQuitHoldTime%
 return
 
 ; Do this stuff when Esc is UP
 ~Esc Up::
-	SetTimer, WaitForESCRelease, Off
-	escIsPressed := false
+  SetTimer, WaitForESCRelease, Off
+  escIsPressed := false
 return
 
 WaitForESCRelease:
-	SetTimer, WaitForESCRelease, Off
-	KillApp()
+  SetTimer, WaitForESCRelease, Off
+  KillApp()
 return
+
+
+; DEBUGGING STUFF
+
+; Number of seconds since midnight.
+SecondsToday() {
+  return A_Hour * 3600 + A_Min * 60 + A_Sec
+}
+
+WriteLog(message)
+{
+  global debug
+  global start
+
+  if (debug) {
+    runningTimeSec := SecondsToday() - start
+    debugLog := "ahk_output.txt"
+    FileAppend,
+    (
+    %runningTimeSec%s %A_Tab% %message%
+
+    ), %debugLog%, UTF-8
+  }
+}
 
 ; KEYMAPS BELOW (NONE IN DEFAULT SCRIPT)

--- a/Assets/Resources/AHK_templates/FlashGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/FlashGameTemplate.txt
@@ -1,45 +1,91 @@
-; FLASH GAME RUN SCRIPT
+; FLASH RUN SCRIPT
 
 #Persistent
 #MaxHotkeysPerInterval 200
+#SingleInstance Force
 
+debug := {DEBUG_OUTPUT}
+
+executable := "{GAME_PATH}"
+game_name := "{GAME_NAME}"
+forceQuitHoldTime := {ESC_HOLD}000
+idleLimit := {IDLE_TIME}000
+initialWait := {IDLE_INITIAL}000
+
+start := SecondsToday()
+WriteLog("START ---------------- " . A_Now)
 
 ; RUN THE GAME
-Run, {GAME_PATH}, , , process_pid
-idleLimit:= {IDLE_TIME}000 ; three seconds
-SetTimer, InitialWait, {IDLE_INITIAL}000
+Run, %executable%, , , process_pid
+WriteLog("Launched " . executable . " with pid " . process_pid)
+
+SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
 MouseMove 3000, 3000, 0
 
-; This is the function that quits the app
+; This is the function that quits the game
 KillApp()
 {
-	WinKill, ahk_exe {GAME_PATH}	; Tries to close using .exe
-	WinKill, ahk_pid process_pid	; Tries to close using process id
-	SetTitleMatchMode, 2
-	WinKill, {GAME_NAME}			; Tries to close hoping that part of the game name is in the title
-	ExitApp
+  global process_pid
+
+  WriteLog("Killing app with pid " . process_pid)
+  WinKill, ahk_exe %executable% ; Tries to close using .exe
+  WinKill, ahk_pid process_pid  ; Tries to close using process id
+  SetTitleMatchMode, 2
+  WinKill, %game_name%      ; Tries to close hoping that part of the game name is in the title
+  ExitApp
+}
+
+; Do this so we don't keep running through InitialWait and CloseOnIdle
+Loop
+{
 }
 
 InitialWait:
-	SetTimer,  CloseOnIdle, % idleLimit+150
+  WriteLog("Completed initial wait")
+  SetTimer,  CloseOnIdle, % idleLimit+150
 return
 
 ; This is the timer
 CloseOnIdle:
-	if (A_TimeIdle>=idleLimit)
-	{
-		KillApp()
-		SetTimer,CloseOnIdle, Off
-	}
-	else
-	{
-		SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
-	}
+  if (A_TimeIdle >= idleLimit)
+  {
+    WriteLog("Idle timeout!")
+    KillApp()
+    SetTimer,CloseOnIdle, Off
+  }
+  else
+  {
+    SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
+  }
 return
 
 ; Do this stuff when Esc is pressed
 ~Esc::
+	WriteLog("ESC pressed")
 	KillApp()
 return
+
+; DEBUGGING STUFF
+
+; Number of seconds since midnight.
+SecondsToday() {
+  return A_Hour * 3600 + A_Min * 60 + A_Sec
+}
+
+WriteLog(message)
+{
+  global debug
+  global start
+
+  if (debug) {
+    runningTimeSec := SecondsToday() - start
+    debugLog := "ahk_output.txt"
+    FileAppend,
+    (
+    %runningTimeSec%s %A_Tab% %message%
+
+    ), %debugLog%, UTF-8
+  }
+}
 
 ; KEYMAPS BELOW

--- a/Assets/Resources/AHK_templates/LegacyGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/LegacyGameTemplate.txt
@@ -1,60 +1,107 @@
-; LEGACY GAME RUN SCRIPT
+; LEGACY RUN SCRIPT
 
 #Persistent
 #MaxHotkeysPerInterval 200
+#SingleInstance Force
 
+debug := {DEBUG_OUTPUT}
+
+executable := "{GAME_PATH}"
+game_name := "{GAME_NAME}"
+forceQuitHoldTime := {ESC_HOLD}000
+idleLimit := {IDLE_TIME}000
+initialWait := {IDLE_INITIAL}000
+
+start := SecondsToday()
+WriteLog("START ---------------- " . A_Now)
 
 ; RUN THE GAME
-Run, {GAME_PATH}, , , process_pid
-idleLimit:= {IDLE_TIME}000 ; three seconds
-SetTimer, InitialWait, {IDLE_INITIAL}000
+Run, %executable%, , , process_pid
+WriteLog("Launched " . executable . " with pid " . process_pid)
+
+SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
 MouseMove 3000, 3000, 0
 
-; This is the function that quits the app
+; This is the function that quits the game
 KillApp()
 {
-	WinKill, ahk_exe {GAME_PATH}	; Tries to close using .exe
-	WinKill, ahk_pid process_pid	; Tries to close using process id
-	SetTitleMatchMode, 2
-	WinKill, {GAME_NAME}			; Tries to close hoping that part of the game name is in the title
-	ExitApp
+  global process_pid
+
+  WriteLog("Killing app with pid " . process_pid)
+  WinKill, ahk_exe %executable% ; Tries to close using .exe
+  WinKill, ahk_pid process_pid  ; Tries to close using process id
+  SetTitleMatchMode, 2
+  WinKill, %game_name%      ; Tries to close hoping that part of the game name is in the title
+  ExitApp
+}
+
+; Do this so we don't keep running through InitialWait and CloseOnIdle
+Loop
+{
 }
 
 InitialWait:
-	SetTimer,  CloseOnIdle, % idleLimit+150
+  WriteLog("Completed initial wait")
+  SetTimer,  CloseOnIdle, % idleLimit+150
 return
 
 ; This is the timer
 CloseOnIdle:
-	if (A_TimeIdle>=idleLimit)
-	{
-		KillApp()
-		SetTimer,CloseOnIdle, Off
-	}
-	else
-	{
-		SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
-	}
+  if (A_TimeIdle >= idleLimit)
+  {
+    WriteLog("Idle timeout!")
+    KillApp()
+    SetTimer,CloseOnIdle, Off
+  }
+  else
+  {
+    SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
+  }
 return
 
 ; Do this stuff when Esc is pressed
 ~Esc::
-	If escIsPressed
-		return
-	escIsPressed := true
-	SetTimer, WaitForESCRelease, {ESC_HOLD}000		; 3 seconds
+  WriteLog("ESC pressed")
+  If escIsPressed
+    return
+  escIsPressed := true
+  SetTimer, WaitForESCRelease, %forceQuitHoldTime%
 return
 
 ; Do this stuff when Esc is UP
 ~Esc Up::
-	SetTimer, WaitForESCRelease, Off
-	escIsPressed := false
+  SetTimer, WaitForESCRelease, Off
+  escIsPressed := false
 return
 
 WaitForESCRelease:
-	SetTimer, WaitForESCRelease, Off
-	KillApp()
+  SetTimer, WaitForESCRelease, Off
+  KillApp()
 return
+
+
+; DEBUGGING STUFF
+
+; Number of seconds since midnight.
+SecondsToday() {
+  return A_Hour * 3600 + A_Min * 60 + A_Sec
+}
+
+WriteLog(message)
+{
+  global debug
+  global start
+
+  if (debug) {
+    runningTimeSec := SecondsToday() - start
+    debugLog := "ahk_output.txt"
+    FileAppend,
+    (
+    %runningTimeSec%s %A_Tab% %message%
+
+    ), %debugLog%, UTF-8
+  }
+}
 
 ; KEYMAPS BELOW
 

--- a/Assets/Resources/AHK_templates/Pico8GameTemplate.txt
+++ b/Assets/Resources/AHK_templates/Pico8GameTemplate.txt
@@ -2,60 +2,106 @@
 
 #Persistent
 #MaxHotkeysPerInterval 200
+#SingleInstance Force
 
+debug := {DEBUG_OUTPUT}
+
+executable := "{GAME_PATH}"
+game_name := "{GAME_NAME}"
+forceQuitHoldTime := {ESC_HOLD}000
+idleLimit := {IDLE_TIME}000
+initialWait := {IDLE_INITIAL}000
+
+start := SecondsToday()
+WriteLog("START ---------------- " . A_Now)
 
 ; RUN THE GAME
-Run, {GAME_PATH}
-SetTitleMatchMode 2
-idleLimit:= {IDLE_TIME}000 ; three seconds
-SetTimer, InitialWait, {IDLE_INITIAL}000
-MouseMove, 3000, 3000, 0
+Run, %executable%, , , process_pid
+WriteLog("Launched " . executable . " with pid " . process_pid)
 
-; This is the function that quits the app
+SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
+MouseMove 3000, 3000, 0
+
+; This is the function that quits the game
 KillApp()
 {
-	WinClose, PICO-8
-	WinKill, PICO-8
-	ExitApp
+  global process_pid
+
+  WinClose, PICO-8
+  WinKill, PICO-8
+  ExitApp
+}
+
+; Do this so we don't keep running through InitialWait and CloseOnIdle
+Loop
+{
 }
 
 InitialWait:
-	SetTimer,  CloseOnIdle, % idleLimit+150
+  WriteLog("Completed initial wait")
+  SetTimer,  CloseOnIdle, % idleLimit+150
 return
 
 ; This is the timer
 CloseOnIdle:
-	if (A_TimeIdle>=idleLimit)
-	{
-		KillApp()
-		SetTimer,CloseOnIdle, Off
-	}
-	else
-	{
-		SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
-	}
+  if (A_TimeIdle >= idleLimit)
+  {
+    WriteLog("Idle timeout!")
+    KillApp()
+    SetTimer,CloseOnIdle, Off
+  }
+  else
+  {
+    SetTimer,CloseOnIdle, % idleLimit-A_TimeIdle+150
+  }
 return
 
 ; Do this stuff when Esc is pressed
 ~Esc::
-	If escIsPressed
-		return
-	escIsPressed := true
-	SetTimer, WaitForESCRelease, {ESC_HOLD}000		; 3 seconds
+  WriteLog("ESC pressed")
+  If escIsPressed
+    return
+  escIsPressed := true
+  SetTimer, WaitForESCRelease, %forceQuitHoldTime%
 return
 
 ; Do this stuff when Esc is UP
 ~Esc Up::
-	SetTimer, WaitForESCRelease, Off
-	escIsPressed := false
+  SetTimer, WaitForESCRelease, Off
+  escIsPressed := false
 return
 
 WaitForESCRelease:
-	SetTimer, WaitForESCRelease, Off
-	KillApp()
+  SetTimer, WaitForESCRelease, Off
+  KillApp()
 return
 
+
+; DEBUGGING STUFF
+
+; Number of seconds since midnight.
+SecondsToday() {
+  return A_Hour * 3600 + A_Min * 60 + A_Sec
+}
+
+WriteLog(message)
+{
+  global debug
+  global start
+
+  if (debug) {
+    runningTimeSec := SecondsToday() - start
+    debugLog := "ahk_output.txt"
+    FileAppend,
+    (
+    %runningTimeSec%s %A_Tab% %message%
+
+    ), %debugLog%, UTF-8
+  }
+}
+
 ; KEYMAPS BELOW
+
 /::m
 .::n
 a::s

--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -230,6 +230,7 @@ public class Game
         //Things needed for every Launcher Script
 
         //Replace variables
+        newAHKfile = newAHKfile.Replace("{DEBUG_OUTPUT}", "true"); // TODO make this configurable
         newAHKfile = newAHKfile.Replace("{IDLE_TIME}", "" + GM.options.runnerSecondsIdle);
         newAHKfile = newAHKfile.Replace("{IDLE_INITIAL}", "" + GM.options.runnerSecondsIdleInitial);
         newAHKfile = newAHKfile.Replace("{ESC_HOLD}", "" + GM.options.runnerSecondsESCHeld);


### PR DESCRIPTION
⚠️ In progress ⚠️ 

There were two bugs here:
- `InitialWait` never worked; the idle timer would be triggered first
- When exiting a game, we'd be stuck at a blank screen for `idleLimit`ms, waiting for the idle timer to trigger an actual exit and kick us back to the menu.

Fixes:
- The infinite loop on line 38: because `InitialWait` is a *label* and not a function, execution would continue through there and start the idle timer long before the initialwait timer triggered.
- Quitting a game via process id didn't work because we were missing the `global process_pid` inside the `KillApp` function; without that, it'd be looking for a local `process_pid` variable, but there isn't one so it would just use a blank value. By adding the `global`, we use the `process_pid` from the outside scope (that gets set with `Run` - that should be a reliable way of killing processes).

Also added the `WriteLog` function for writing debug messages. You can turn off the actual write by setting `debug` to false on line 7.

