### PR TITLE
No really: reliable force-quit/idle.

### DIFF
--- a/Assets/Resources/AHK_templates/ExeGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/ExeGameTemplate.txt
@@ -7,6 +7,7 @@
 debug := {DEBUG_OUTPUT}
 
 executable := "{GAME_PATH}"
+exec_file := "{GAME_FILE}"
 game_name := "{GAME_NAME}"
 forceQuitHoldTime := {ESC_HOLD}000
 idleLimit := {IDLE_TIME}000
@@ -15,33 +16,68 @@ initialWait := {IDLE_INITIAL}000
 start := SecondsToday()
 WriteLog("START ---------------- " . A_Now)
 
+SetTitleMatchMode, 2
+
 ; RUN THE GAME
-Run, %executable%, , , process_pid
-WriteLog("Launched " . executable . " with pid " . process_pid)
+Run, %executable%, , , process_id_1
+WriteLog("Launched " . executable . " with pid " . process_id_1)
 
 SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
 MouseMove 3000, 3000, 0
 
-; This is the function that quits the game
+; This is the function that quits the game (hopefully)
 KillApp()
 {
-  global process_pid
+  global process_id_1
+  global process_id_2
 
-  WriteLog("Killing app with pid " . process_pid)
+  WriteLog("Killing app with pids " . process_id_1 . " and " . process_id_2)
+  
+  ; Nuke the site from orbit. SOMETHING should work....
+
   WinKill, ahk_exe %executable% ; Tries to close using .exe
-  WinKill, ahk_pid process_pid  ; Tries to close using process id
-  SetTitleMatchMode, 2
-  WinKill, Nidhogg      ; Tries to close hoping that part of the game name is in the title
+  WinKill, ahk_exe %exec_file%
+
+  WinKill, ahk_pid process_id_2 ; Tries to close using process id
+  WinKill, ahk_pid process_id_1  
+
+  WinKill, %game_name%
+
+  Run, TaskKill /f /pid %process_id_2%
+  Run, TaskKill /f /pid %process_id_1%
+  Run, TaskKill /f /im %exec_file%
+  
+  IfWinExist, "WinnitronLauncher!"
+  {
+    WriteLog("winnitron window id " . WinExist("A"))
+    WinActivate
+    WinMaximize
+  } else {
+    WriteLog("couldn't find winnitron window")
+  }
+
   ExitApp
 }
 
-; Do this so we don't keep running through InitialWait and CloseOnIdle
 Loop
 {
+  ; Ensure that the AHK script exits when the game does, because it's *this*
+  ; process that the Launcher is watching so it knows when to wake up and
+  ; kick back to menu.
+  Process, Exist, %process_id_1%
+  if (ErrorLevel == 0) {
+    WriteLog("detected game not running")
+    KillApp()
+  }
+
 }
 
 InitialWait:
-  WriteLog("Completed initial wait")
+  ; Some games launch a second process
+  WinGet, process_id_2, PID, %game_name%
+  
+  WriteLog("Completed initial wait (pid2: " . process_id_2 . ")")
+
   SetTimer,  CloseOnIdle, % idleLimit+150
 return
 
@@ -61,7 +97,6 @@ return
 
 ; Do this stuff when Esc is pressed
 ~Esc::
-  WriteLog("ESC pressed")
   If escIsPressed
     return
   escIsPressed := true
@@ -103,4 +138,4 @@ WriteLog(message)
   }
 }
 
-; KEYMAPS BELOW (NONE IN DEFAULT SCRIPT)
+; KEYMAPS BELOW (none in default)

--- a/Assets/Resources/AHK_templates/ExeGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/ExeGameTemplate.txt
@@ -46,12 +46,14 @@ KillApp()
   Run, TaskKill /f /pid %process_id_2%
   Run, TaskKill /f /pid %process_id_1%
   Run, TaskKill /f /im %exec_file%
-  
-  IfWinExist, "WinnitronLauncher!"
+
+  SetTitleMatchMode, RegEx
+  IfWinExist, i)WinnitronLauncher
   {
     WriteLog("winnitron window id " . WinExist("A"))
-    WinActivate
-    WinMaximize
+    WinActivate, i)WinnitronLauncher
+    WinWaitActive, i)WinnitronLauncher, , 2
+    PostMessage, 0x112, 0xF030,,, i)WinnitronLauncher  ; 0x112 = WM_SYSCOMMAND, 0xF030 = SC_MAXIMIZE
   } else {
     WriteLog("couldn't find winnitron window")
   }

--- a/Assets/Resources/AHK_templates/FlashGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/FlashGameTemplate.txt
@@ -7,6 +7,7 @@
 debug := {DEBUG_OUTPUT}
 
 executable := "{GAME_PATH}"
+exec_file := "{GAME_FILE}"
 game_name := "{GAME_NAME}"
 forceQuitHoldTime := {ESC_HOLD}000
 idleLimit := {IDLE_TIME}000
@@ -16,32 +17,66 @@ start := SecondsToday()
 WriteLog("START ---------------- " . A_Now)
 
 ; RUN THE GAME
-Run, %executable%, , , process_pid
-WriteLog("Launched " . executable . " with pid " . process_pid)
+Run, %executable%, , , process_id_1
+WriteLog("Launched " . executable . " with pid " . process_pid_1)
 
 SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
 MouseMove 3000, 3000, 0
 
-; This is the function that quits the game
+; This is the function that quits the game (hopefully)
 KillApp()
 {
-  global process_pid
+  global process_id_1
+  global process_id_2
 
-  WriteLog("Killing app with pid " . process_pid)
+  WriteLog("Killing app with pids " . process_id_1 . " and " . process_id_2)
+  
+  ; Nuke the site from orbit. SOMETHING should work....
+
   WinKill, ahk_exe %executable% ; Tries to close using .exe
-  WinKill, ahk_pid process_pid  ; Tries to close using process id
-  SetTitleMatchMode, 2
-  WinKill, %game_name%      ; Tries to close hoping that part of the game name is in the title
+  WinKill, ahk_exe %exec_file%
+
+  WinKill, ahk_pid process_id_2 ; Tries to close using process id
+  WinKill, ahk_pid process_id_1  
+
+  WinKill, %game_name%
+
+  Run, TaskKill /f /pid %process_id_2%
+  Run, TaskKill /f /pid %process_id_1%
+  Run, TaskKill /f /im %exec_file%
+  
+  IfWinExist, "WinnitronLauncher!"
+  {
+    WriteLog("winnitron window id " . WinExist("A"))
+    WinActivate
+    WinMaximize
+  } else {
+    WriteLog("couldn't find winnitron window")
+  }
+
   ExitApp
 }
 
-; Do this so we don't keep running through InitialWait and CloseOnIdle
 Loop
 {
+  ; Ensure that the AHK script exits when the game does, because it's *this*
+  ; process that the Launcher is watching so it knows when to wake up and
+  ; kick back to menu.
+  Process, Exist, %process_id_1%
+  if (ErrorLevel == 0) {
+    WriteLog("detected game not running")
+    KillApp()
+  }
+
 }
 
 InitialWait:
-  WriteLog("Completed initial wait")
+  ; Some games launch a second process
+  SetTitleMatchMode, 2
+  WinGet, process_id_2, PID, %game_name%
+  
+  WriteLog("Completed initial wait (pid2: " . process_id_2 . ")")
+
   SetTimer,  CloseOnIdle, % idleLimit+150
 return
 

--- a/Assets/Resources/AHK_templates/FlashGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/FlashGameTemplate.txt
@@ -126,3 +126,13 @@ WriteLog(message)
 }
 
 ; KEYMAPS BELOW
+
+.::z
+/::x
+
+w::i
+a::j
+s::k
+d::l
+`::n
+1::m

--- a/Assets/Resources/AHK_templates/FlashGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/FlashGameTemplate.txt
@@ -45,11 +45,13 @@ KillApp()
   Run, TaskKill /f /pid %process_id_1%
   Run, TaskKill /f /im %exec_file%
   
-  IfWinExist, "WinnitronLauncher!"
+  SetTitleMatchMode, RegEx
+  IfWinExist, i)winnitron
   {
     WriteLog("winnitron window id " . WinExist("A"))
-    WinActivate
+    WinActivate, i)winnitron
     WinMaximize
+    PostMessage, 0x112, 0xF030,,, i)winnitron  ; 0x112 = WM_SYSCOMMAND, 0xF030 = SC_MAXIMIZE
   } else {
     WriteLog("couldn't find winnitron window")
   }

--- a/Assets/Resources/AHK_templates/LegacyGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/LegacyGameTemplate.txt
@@ -7,6 +7,7 @@
 debug := {DEBUG_OUTPUT}
 
 executable := "{GAME_PATH}"
+exec_file := "{GAME_FILE}"
 game_name := "{GAME_NAME}"
 forceQuitHoldTime := {ESC_HOLD}000
 idleLimit := {IDLE_TIME}000
@@ -15,33 +16,68 @@ initialWait := {IDLE_INITIAL}000
 start := SecondsToday()
 WriteLog("START ---------------- " . A_Now)
 
+SetTitleMatchMode, 2
+
 ; RUN THE GAME
-Run, %executable%, , , process_pid
-WriteLog("Launched " . executable . " with pid " . process_pid)
+Run, %executable%, , , process_id_1
+WriteLog("Launched " . executable . " with pid " . process_id_1)
 
 SetTimer, InitialWait, -%initialWait% ; negative period disables timer after first trigger
 MouseMove 3000, 3000, 0
 
-; This is the function that quits the game
+; This is the function that quits the game (hopefully)
 KillApp()
 {
-  global process_pid
+  global process_id_1
+  global process_id_2
 
-  WriteLog("Killing app with pid " . process_pid)
+  WriteLog("Killing app with pids " . process_id_1 . " and " . process_id_2)
+  
+  ; Nuke the site from orbit. SOMETHING should work....
+
   WinKill, ahk_exe %executable% ; Tries to close using .exe
-  WinKill, ahk_pid process_pid  ; Tries to close using process id
-  SetTitleMatchMode, 2
-  WinKill, %game_name%      ; Tries to close hoping that part of the game name is in the title
+  WinKill, ahk_exe %exec_file%
+
+  WinKill, ahk_pid process_id_2 ; Tries to close using process id
+  WinKill, ahk_pid process_id_1  
+
+  WinKill, %game_name%
+
+  Run, TaskKill /f /pid %process_id_2%
+  Run, TaskKill /f /pid %process_id_1%
+  Run, TaskKill /f /im %exec_file%
+  
+  IfWinExist, "WinnitronLauncher!"
+  {
+    WriteLog("winnitron window id " . WinExist("A"))
+    WinActivate
+    WinMaximize
+  } else {
+    WriteLog("couldn't find winnitron window")
+  }
+
   ExitApp
 }
 
-; Do this so we don't keep running through InitialWait and CloseOnIdle
 Loop
 {
+  ; Ensure that the AHK script exits when the game does, because it's *this*
+  ; process that the Launcher is watching so it knows when to wake up and
+  ; kick back to menu.
+  Process, Exist, %process_id_1%
+  if (ErrorLevel == 0) {
+    WriteLog("detected game not running")
+    KillApp()
+  }
+
 }
 
 InitialWait:
-  WriteLog("Completed initial wait")
+  ; Some games launch a second process
+  WinGet, process_id_2, PID, %game_name%
+  
+  WriteLog("Completed initial wait (pid2: " . process_id_2 . ")")
+
   SetTimer,  CloseOnIdle, % idleLimit+150
 return
 
@@ -61,7 +97,6 @@ return
 
 ; Do this stuff when Esc is pressed
 ~Esc::
-  WriteLog("ESC pressed")
   If escIsPressed
     return
   escIsPressed := true

--- a/Assets/Resources/AHK_templates/LegacyGameTemplate.txt
+++ b/Assets/Resources/AHK_templates/LegacyGameTemplate.txt
@@ -47,11 +47,13 @@ KillApp()
   Run, TaskKill /f /pid %process_id_1%
   Run, TaskKill /f /im %exec_file%
   
-  IfWinExist, "WinnitronLauncher!"
+  SetTitleMatchMode, RegEx
+  IfWinExist, i)WinnitronLauncher
   {
     WriteLog("winnitron window id " . WinExist("A"))
-    WinActivate
-    WinMaximize
+    WinActivate, i)WinnitronLauncher
+    WinWaitActive, i)WinnitronLauncher, , 2
+    PostMessage, 0x112, 0xF030,,, i)WinnitronLauncher  ; 0x112 = WM_SYSCOMMAND, 0xF030 = SC_MAXIMIZE
   } else {
     WriteLog("couldn't find winnitron window")
   }

--- a/Assets/Resources/AHK_templates/Pico8GameTemplate.txt
+++ b/Assets/Resources/AHK_templates/Pico8GameTemplate.txt
@@ -29,6 +29,18 @@ KillApp()
 
   WinClose, PICO-8
   WinKill, PICO-8
+
+  SetTitleMatchMode, RegEx
+  IfWinExist, i)winnitron
+  {
+    WriteLog("winnitron window id " . WinExist("A"))
+    WinActivate, i)winnitron
+    WinMaximize
+    PostMessage, 0x112, 0xF030,,, i)winnitron  ; 0x112 = WM_SYSCOMMAND, 0xF030 = SC_MAXIMIZE
+  } else {
+    WriteLog("couldn't find winnitron window")
+  }
+
   ExitApp
 }
 

--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -183,6 +183,7 @@ public class Game
         GM.dbug.Log("GAME: Create scripts for game " + name);
 
         string newAHKfile = "";
+        string execFile = Path.GetFileName(executable);
 
         switch (gameType)
         {
@@ -231,6 +232,7 @@ public class Game
         //Things needed for every Launcher Script
 
         //Replace variables
+        newAHKfile = newAHKfile.Replace("{GAME_FILE}", execFile);
         newAHKfile = newAHKfile.Replace("{DEBUG_OUTPUT}", "true"); // TODO make this configurable
         newAHKfile = newAHKfile.Replace("{IDLE_TIME}", "" + GM.options.runnerSecondsIdle);
         newAHKfile = newAHKfile.Replace("{IDLE_INITIAL}", "" + GM.options.runnerSecondsIdleInitial);

--- a/Assets/Scripts/System/GM.cs
+++ b/Assets/Scripts/System/GM.cs
@@ -8,7 +8,7 @@ public class GM : Singleton<GM> {
     public string versionNumber;
     public static string VersionNumber;
 
-	//reference to the 
+	//reference to the
 	public static Runner runner;
 	public static DataManager data;
     public static OptionsManager options;
@@ -22,7 +22,7 @@ public class GM : Singleton<GM> {
         VersionNumber = versionNumber;
         Debug.Log("#####  VERSION " + versionNumber + " #####");
 
-		//Cursor.visible = false;
+		Cursor.visible = false;
 
 		runner = GetComponent<Runner>();
 		data = GetComponent<DataManager> ();
@@ -76,9 +76,9 @@ public class GM : Singleton<GM> {
 
 	/*
 	 *   VERY IMPORTANT!!!!!!
-	 * 	
+	 *
 	 * 	 Comment out the text below in order to debug on non-windows properly
-	 *   
+	 *
 	 */
 
 	//*

--- a/Assets/Scripts/System/Runner.cs
+++ b/Assets/Scripts/System/Runner.cs
@@ -50,6 +50,7 @@ public class Runner : MonoBehaviour {
 
         process.Start();
         process.WaitForExit();
+        process.Close();
 
         GM.dbug.Log(this, "RUNNER: Finished running game " + process.StartInfo.FileName);
 


### PR DESCRIPTION
⚠️ in progress

- [x] better AHK
  - fuckin' serious about force-quitting an idle/crashed game
  - check that a game has quit and exit the AHK script too (fixes lag between game-quit and back-to-menu)
- [ ] ~~*maybe this pr?* The AHK templates are really repetitive (e.g. the only difference between legacy and default is the key map), so it'd be nice to do some `include`s or something to DRY it up.~~