### PR TITLE
Log levels

### DIFF
--- a/Assets/Options/Defaults/winnitron_options.json
+++ b/Assets/Options/Defaults/winnitron_options.json
@@ -35,7 +35,8 @@
     }
   },
   "logger": {
-    "token": ""
+    "token": "YOUR LOGGLY API KEY HERE (optional)",
+    "level": "info"
   },
   "keycodes": {
     "player1": {

--- a/Assets/Scenes/Launcher.unity
+++ b/Assets/Scenes/Launcher.unity
@@ -449,7 +449,9 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Error text goes here. '
+  m_Text: 'Something went wrong.
+
+    Check output_log.txt'
 --- !u!222 &73695449
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -5368,7 +5370,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Press Q to quit
+  m_Text: Press ESC to quit
 --- !u!222 &854943842
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -13376,6 +13378,7 @@ MonoBehaviour:
   initializing: 1
   tweenTime: 0.5
   dataPath: 
+  defaultOptionsPath: 
   optionsPath: 
   playlistsPath: /Playlists
   musicPath: /Music
@@ -13383,19 +13386,6 @@ MonoBehaviour:
   runnerSecondsIdle: 10
   runnerSecondsESCHeld: 3
   runnerSecondsIdleInitial: 30
-  keys:
-    P1Up: 273
-    P1Down: 274
-    P1Left: 276
-    P1Right: 275
-    P1Button1: 47
-    P1Button2: 46
-    P2Up: 119
-    P2Down: 115
-    P2Left: 97
-    P2Right: 100
-    P2Button1: 94
-    P2Button2: 49
 --- !u!114 &1803195759
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Graphics/TesselatedPlane.cs
+++ b/Assets/Scripts/Graphics/TesselatedPlane.cs
@@ -7,7 +7,7 @@ public class TesselatedPlane : MonoBehaviour {
 	public Transform farResetPoint;
 
 	void OnTriggerEnter(Collider other) {
-		//GM.dbug.Log(this, "Collided with " + other.name);
+		GM.dbug.Debug(this, "Collided with " + other.name);
 
 		if (other.name == "Close Plane Trigger") {
 			gameObject.transform.position = farResetPoint.position;

--- a/Assets/Scripts/Graphics/TesselatedPlane.cs
+++ b/Assets/Scripts/Graphics/TesselatedPlane.cs
@@ -7,7 +7,7 @@ public class TesselatedPlane : MonoBehaviour {
 	public Transform farResetPoint;
 
 	void OnTriggerEnter(Collider other) {
-		GM.dbug.Debug(this, "Collided with " + other.name);
+		GM.logger.Debug(this, "Collided with " + other.name);
 
 		if (other.name == "Close Plane Trigger") {
 			gameObject.transform.position = farResetPoint.position;

--- a/Assets/Scripts/Launcher/LauncherUIController.cs
+++ b/Assets/Scripts/Launcher/LauncherUIController.cs
@@ -43,14 +43,14 @@ public class LauncherUIController : MonoBehaviour
         //Hook in the UpdateData function to the DataManager's
         //Update data function so we always get the data at the
         //right time
-        GM.dbug.Info(this, "LauncherUIController: Hooking in OnDataUpdated delegate");
+        GM.logger.Info(this, "LauncherUIController: Hooking in OnDataUpdated delegate");
         GM.data.OnDataUpdated += UpdateData;
     }
 
     void UpdateData()
     {
         //Called when the DataManager finishes updating the data model
-        GM.dbug.Info(this, "LauncherUIController: Updating Data!");
+        GM.logger.Info(this, "LauncherUIController: Updating Data!");
         playlistData = GM.data.playlists;
         BuildPlaylists();
     }

--- a/Assets/Scripts/Launcher/LauncherUIController.cs
+++ b/Assets/Scripts/Launcher/LauncherUIController.cs
@@ -43,14 +43,14 @@ public class LauncherUIController : MonoBehaviour
         //Hook in the UpdateData function to the DataManager's
         //Update data function so we always get the data at the
         //right time
-        GM.dbug.Log(this, "LauncherUIController: Hooking in OnDataUpdated delegate");
+        GM.dbug.Info(this, "LauncherUIController: Hooking in OnDataUpdated delegate");
         GM.data.OnDataUpdated += UpdateData;
     }
 
     void UpdateData()
     {
         //Called when the DataManager finishes updating the data model
-        GM.dbug.Log(this, "LauncherUIController: Updating Data!");
+        GM.dbug.Info(this, "LauncherUIController: Updating Data!");
         playlistData = GM.data.playlists;
         BuildPlaylists();
     }

--- a/Assets/Scripts/System/AttractImgManager.cs
+++ b/Assets/Scripts/System/AttractImgManager.cs
@@ -33,7 +33,7 @@ public class AttractImgManager :  MonoBehaviour {
                 GM.state.ChangeState(StateManager.WorldState.Launcher);
 
             if (timePassed == 0) {
-				GM.dbug.Debug(this, "hey!  first time running attract");
+				GM.logger.Debug(this, "hey!  first time running attract");
 				slideNum = -1;
 				NextSlide();
 			}
@@ -62,7 +62,7 @@ public class AttractImgManager :  MonoBehaviour {
 
 		slideNum += 1;
 
-		GM.dbug.Debug(this, "Calling Next Slide: " + slideNum + " of " + attractSprites.Count);
+		GM.logger.Debug(this, "Calling Next Slide: " + slideNum + " of " + attractSprites.Count);
 
 		if (slideNum > attractSprites.Count - 1) slideNum = 0;
 
@@ -73,16 +73,16 @@ public class AttractImgManager :  MonoBehaviour {
 	}
 
 	void BuildAttractImagesList() {
-    GM.dbug.Info(this, "Attract path: " + GM.options.attractPath);
+    GM.logger.Info(this, "Attract path: " + GM.options.attractPath);
 		var attractDir = new DirectoryInfo(GM.options.attractPath);
 
 		foreach (var attractImg in attractDir.GetFiles()) {
 			//Make sure only .png's get through!
-			GM.dbug.Debug(this, "Loading image with ending: " + attractImg.FullName.Substring(Math.Max(0, attractImg.FullName.Length - 4)) + ".png");
+			GM.logger.Debug(this, "Loading image with ending: " + attractImg.FullName.Substring(Math.Max(0, attractImg.FullName.Length - 4)) + ".png");
 			if(attractImg.FullName.Substring(Math.Max(0, attractImg.FullName.Length - 4)) == ".png") {
 				GameObject newImgObj = Instantiate(attractSpritePrefab, new Vector3(0, -36.52403f, 0), transform.rotation) as GameObject;
 
-				GM.dbug.Debug(this, "Load Attract Image: " + attractImg);
+				GM.logger.Debug(this, "Load Attract Image: " + attractImg);
         // Load the screenshot from the games directory as a Texture2D
         var SpriteTexture = new Texture2D(1024, 768);
         SpriteTexture.LoadImage(File.ReadAllBytes(attractImg.FullName));

--- a/Assets/Scripts/System/AttractImgManager.cs
+++ b/Assets/Scripts/System/AttractImgManager.cs
@@ -15,14 +15,14 @@ public class AttractImgManager :  MonoBehaviour {
 	public int slideNum = 0;
 
 	public bool switchDelay = false;
-	
+
 	void Start() {
 		BuildAttractImagesList();
 		ResetSlides();
 	}
 
 	void Update() {
-		
+
         //Make sure you're only doing stuff if it's actually the Attract state
         //Cause pesky Unity might be running this even if this component is disabled
         //CAN'T TRUST IT
@@ -33,7 +33,7 @@ public class AttractImgManager :  MonoBehaviour {
                 GM.state.ChangeState(StateManager.WorldState.Launcher);
 
             if (timePassed == 0) {
-				// GM.dbug.Log(this, "hey!  first time running attract");
+				GM.dbug.Debug(this, "hey!  first time running attract");
 				slideNum = -1;
 				NextSlide();
 			}
@@ -62,7 +62,7 @@ public class AttractImgManager :  MonoBehaviour {
 
 		slideNum += 1;
 
-		// GM.dbug.Log(this, "Calling Next Slide: " + slideNum + " of " + attractSprites.Count);
+		GM.dbug.Debug(this, "Calling Next Slide: " + slideNum + " of " + attractSprites.Count);
 
 		if (slideNum > attractSprites.Count - 1) slideNum = 0;
 
@@ -73,19 +73,19 @@ public class AttractImgManager :  MonoBehaviour {
 	}
 
 	void BuildAttractImagesList() {
-        GM.dbug.Log(this, "attract " + GM.options.attractPath);
+    GM.dbug.Info(this, "Attract path: " + GM.options.attractPath);
 		var attractDir = new DirectoryInfo(GM.options.attractPath);
-		
+
 		foreach (var attractImg in attractDir.GetFiles()) {
 			//Make sure only .png's get through!
-			GM.dbug.Log(this, "Loading image with ending: " + attractImg.FullName.Substring(Math.Max(0, attractImg.FullName.Length - 4)) + ".png");
+			GM.dbug.Debug(this, "Loading image with ending: " + attractImg.FullName.Substring(Math.Max(0, attractImg.FullName.Length - 4)) + ".png");
 			if(attractImg.FullName.Substring(Math.Max(0, attractImg.FullName.Length - 4)) == ".png") {
-				GameObject newImgObj = Instantiate(attractSpritePrefab, new Vector3(0, -36.52403f, 0), transform.rotation) as GameObject; 
+				GameObject newImgObj = Instantiate(attractSpritePrefab, new Vector3(0, -36.52403f, 0), transform.rotation) as GameObject;
 
-				GM.dbug.Log(this, "Load Attract Image: " + attractImg);
-                // Load the screenshot from the games directory as a Texture2D
-                var SpriteTexture = new Texture2D(1024, 768);
-                SpriteTexture.LoadImage(File.ReadAllBytes(attractImg.FullName));
+				GM.dbug.Debug(this, "Load Attract Image: " + attractImg);
+        // Load the screenshot from the games directory as a Texture2D
+        var SpriteTexture = new Texture2D(1024, 768);
+        SpriteTexture.LoadImage(File.ReadAllBytes(attractImg.FullName));
 
 				newImgObj.GetComponent<Image>().sprite = Sprite.Create(SpriteTexture, new Rect(0, 0, 1024, 768), new Vector2(0.5f, 0.5f));
 				newImgObj.transform.SetParent (transform);
@@ -95,4 +95,3 @@ public class AttractImgManager :  MonoBehaviour {
 		}
 	}
 }
-	

--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -42,13 +42,13 @@ public class Game
     /// Builds a game from scratch using only what it can find in the directory.
     /// </summary>
     private void BuildGame() {
-        GM.dbug.Warn("GAME: No JSON!  Determining game...");
+        GM.logger.Warn("GAME: No JSON!  Determining game...");
 
         if (DetermineGameType()) {
             this.name = GetGameNameFromFolderName();
             this.screenshot = GetScreenshot();
         } else {
-            GM.dbug.Error("GAME: Could not determine game type.  Voiding game " + directory);
+            GM.logger.Error("GAME: Could not determine game type.  Voiding game " + directory);
             voidGame = true;
         }
     }
@@ -90,7 +90,7 @@ public class Game
                 break;
         }
 
-        GM.dbug.Info(null, "Game Built JSON! Name: " + name + " Screenshot: " + screenshot.name + " exe path: " + executable);
+        GM.logger.Info(null, "Game Built JSON! Name: " + name + " Screenshot: " + screenshot.name + " exe path: " + executable);
     }
 
 
@@ -104,17 +104,17 @@ public class Game
 
         if (Directory.GetFiles(this.directory.ToString(), "*.png").Length > 0)
         {
-            GM.dbug.Info("GAME: Loading custom screenshot " + Directory.GetFiles(this.directory.ToString(), "*.png")[0]);
+            GM.logger.Info("GAME: Loading custom screenshot " + Directory.GetFiles(this.directory.ToString(), "*.png")[0]);
             screenshotTex.LoadImage(File.ReadAllBytes(Directory.GetFiles(directory.FullName + Path.DirectorySeparatorChar, "*.png")[0]));
         }
         else if (gameType == GameType.PICO8)
         {
-            GM.dbug.Info("GAME: Loading default PICO8 screenshot ");
+            GM.logger.Info("GAME: Loading default PICO8 screenshot ");
             screenshotTex = Resources.Load<Texture2D>("default_images/pico8") as Texture2D;
         }
         else
         {
-            GM.dbug.Info("GAME: Loading default screenshot");
+            GM.logger.Info("GAME: Loading default screenshot");
             screenshotTex = Resources.Load<Texture2D>("default_images/exe") as Texture2D;
         }
 
@@ -146,13 +146,13 @@ public class Game
         if (Directory.GetFiles(this.directory.ToString(), "*.html").Length == 1)
         {
             executable = Directory.GetFiles(this.directory.ToString(), "*.html")[0];
-            GM.dbug.Info("Determined PICO8! " + executable);
+            GM.logger.Info("Determined PICO8! " + executable);
             gameType = GameType.PICO8;
             return true;
         }
         else if (Directory.GetFiles(this.directory.ToString(), "*.exe").Length == 1)
         {
-            GM.dbug.Info("Determined EXE!");
+            GM.logger.Info("Determined EXE!");
             executable = Directory.GetFiles(this.directory.ToString(), "*.exe")[0];
             gameType = GameType.EXE;
             return true;
@@ -168,7 +168,7 @@ public class Game
     /// and put them in the same folder as the game.
     /// </summary>
     public void BuildHelperScripts() {
-        GM.dbug.Info("GAME: Create scripts for game " + name);
+        GM.logger.Info("GAME: Create scripts for game " + name);
 
         string newAHKfile = "";
         string execFile = Path.GetFileName(executable);
@@ -240,7 +240,7 @@ public class Game
             string source = Path.Combine(directory.ToString(), "Pico8Launcher.js");
             string dest   = Path.Combine(GM.options.dataPath, "Options/Pico8/Pico8Launcher.js");
 
-            GM.dbug.Info("GAME: PreRun copying " + source + " to " + dest);
+            GM.logger.Info("GAME: PreRun copying " + source + " to " + dest);
             File.Copy(source, dest, true);
         }
     }
@@ -286,6 +286,6 @@ public class Game
 
         File.Delete(file);
         System.IO.File.WriteAllText(file, text);
-        GM.dbug.Info("GAME: Writing file " + file);
+        GM.logger.Info("GAME: Writing file " + file);
     }
 }

--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -42,16 +42,13 @@ public class Game
     /// Builds a game from scratch using only what it can find in the directory.
     /// </summary>
     private void BuildGame() {
-        GM.dbug.Log("GAME: No JSON!  Determining game...");
-        if (DetermineGameType())
-        {
+        GM.dbug.Warn("GAME: No JSON!  Determining game...");
+
+        if (DetermineGameType()) {
             this.name = GetGameNameFromFolderName();
             this.screenshot = GetScreenshot();
-        }
-
-        else
-        {
-            GM.dbug.Log("GAME: Could not determine game type.  Voiding game " + directory);
+        } else {
+            GM.dbug.Error("GAME: Could not determine game type.  Voiding game " + directory);
             voidGame = true;
         }
     }
@@ -93,7 +90,7 @@ public class Game
                 break;
         }
 
-        GM.dbug.Log(null, "Game Built JSON! Name: " + name + " Screenshot: " + screenshot.name + " exe path: " + executable);
+        GM.dbug.Info(null, "Game Built JSON! Name: " + name + " Screenshot: " + screenshot.name + " exe path: " + executable);
     }
 
 
@@ -107,17 +104,17 @@ public class Game
 
         if (Directory.GetFiles(this.directory.ToString(), "*.png").Length > 0)
         {
-            GM.dbug.Log("GAME: Loading custom screenshot " + Directory.GetFiles(this.directory.ToString(), "*.png")[0]);
+            GM.dbug.Info("GAME: Loading custom screenshot " + Directory.GetFiles(this.directory.ToString(), "*.png")[0]);
             screenshotTex.LoadImage(File.ReadAllBytes(Directory.GetFiles(directory.FullName + Path.DirectorySeparatorChar, "*.png")[0]));
         }
         else if (gameType == GameType.PICO8)
         {
-            GM.dbug.Log("GAME: Loading default PICO8 screenshot ");
+            GM.dbug.Info("GAME: Loading default PICO8 screenshot ");
             screenshotTex = Resources.Load<Texture2D>("default_images/pico8") as Texture2D;
         }
         else
         {
-            GM.dbug.Log("GAME: Loading default screenshot");
+            GM.dbug.Info("GAME: Loading default screenshot");
             screenshotTex = Resources.Load<Texture2D>("default_images/exe") as Texture2D;
         }
 
@@ -149,13 +146,13 @@ public class Game
         if (Directory.GetFiles(this.directory.ToString(), "*.html").Length == 1)
         {
             executable = Directory.GetFiles(this.directory.ToString(), "*.html")[0];
-            Debug.Log("Determined PICO8! " + executable);
+            GM.dbug.Info("Determined PICO8! " + executable);
             gameType = GameType.PICO8;
             return true;
         }
         else if (Directory.GetFiles(this.directory.ToString(), "*.exe").Length == 1)
         {
-            Debug.Log("Determined EXE!");
+            GM.dbug.Info("Determined EXE!");
             executable = Directory.GetFiles(this.directory.ToString(), "*.exe")[0];
             gameType = GameType.EXE;
             return true;
@@ -171,7 +168,7 @@ public class Game
     /// and put them in the same folder as the game.
     /// </summary>
     public void BuildHelperScripts() {
-        GM.dbug.Log("GAME: Create scripts for game " + name);
+        GM.dbug.Info("GAME: Create scripts for game " + name);
 
         string newAHKfile = "";
         string execFile = Path.GetFileName(executable);
@@ -243,7 +240,7 @@ public class Game
             string source = Path.Combine(directory.ToString(), "Pico8Launcher.js");
             string dest   = Path.Combine(GM.options.dataPath, "Options/Pico8/Pico8Launcher.js");
 
-            GM.dbug.Log("GAME: PreRun copying " + source + " to " + dest);
+            GM.dbug.Info("GAME: PreRun copying " + source + " to " + dest);
             File.Copy(source, dest, true);
         }
     }
@@ -257,7 +254,7 @@ public class Game
 
             try {
                 playerKeys = savedMetadata["keys"]["bindings"][pNum.ToString()];
-            } catch (System.NullReferenceException e) {
+            } catch (System.NullReferenceException) {
                 break;
             }
 
@@ -287,9 +284,8 @@ public class Game
     private void WriteStringToFile(string text, string fileName) {
         string file = Path.Combine(directory.FullName, fileName);
 
-        //Delete old file and write to new one
         File.Delete(file);
         System.IO.File.WriteAllText(file, text);
-        GM.dbug.Log("GAME: Writing file " + file);
+        GM.dbug.Info("GAME: Writing file " + file);
     }
 }

--- a/Assets/Scripts/System/Data/Playlist.cs
+++ b/Assets/Scripts/System/Data/Playlist.cs
@@ -12,18 +12,18 @@ public class Playlist
 
 	/*
 	 *  Playlist Constructor
-	 * 
-	 *  Playlist only takes in the directory that the DataManager hands it 
+	 *
+	 *  Playlist only takes in the directory that the DataManager hands it
 	 *  and builds everything from there
 	 */
-	public Playlist(string directory) 
+	public Playlist(string directory)
 	{
 		//Find out the name of the directory
 		this.directory = new DirectoryInfo(directory);
 
         name = this.directory.Name;
 
-        Debug.Log("Playlist: Name before fixes " + name);
+        GM.dbug.Debug("Playlist: Name before fixes " + name);
 
         name = name.TrimStart('_');
         name = name.Replace('_', ' ').Replace('-', ' ');
@@ -31,7 +31,7 @@ public class Playlist
         //Replace the underscores for a cleaner name
         name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name);
 
-        Debug.Log("Playlist: Name after fixes " + name);
+        GM.dbug.Debug("Playlist: Name after fixes " + name);
 
         //Init the games list
         this.games = new List<Game>();
@@ -49,21 +49,21 @@ public class Playlist
 
 	//Where the magic happens
 	public void BuildPlaylist()
-	{	
-		foreach (var gameDir in directory.GetDirectories()) 
+	{
+		foreach (var gameDir in directory.GetDirectories())
 		{
 			//Don't pick any directories that start with a dot
-			if(!gameDir.Name.Substring(0, 1).Equals(".")) 
+			if(!gameDir.Name.Substring(0, 1).Equals("."))
 			{
-				//Make a new game                
+				//Make a new game
 				Game newGame = new Game(gameDir.FullName);
 
 				//Add a game!  Pass the Game constructor the directory where the game is contained
 				games.Add(newGame);
 			}
-		}   
+		}
 
-		GM.dbug.Log(null, "Playlist Built! : " + name);
+		GM.dbug.Info(null, "Playlist Built! : " + name);
 	}
 
 	public void BuildPlaylistJSON()

--- a/Assets/Scripts/System/Data/Playlist.cs
+++ b/Assets/Scripts/System/Data/Playlist.cs
@@ -23,7 +23,7 @@ public class Playlist
 
         name = this.directory.Name;
 
-        GM.dbug.Debug("Playlist: Name before fixes " + name);
+        GM.logger.Debug("Playlist: Name before fixes " + name);
 
         name = name.TrimStart('_');
         name = name.Replace('_', ' ').Replace('-', ' ');
@@ -31,7 +31,7 @@ public class Playlist
         //Replace the underscores for a cleaner name
         name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name);
 
-        GM.dbug.Debug("Playlist: Name after fixes " + name);
+        GM.logger.Debug("Playlist: Name after fixes " + name);
 
         //Init the games list
         this.games = new List<Game>();
@@ -63,7 +63,7 @@ public class Playlist
 			}
 		}
 
-		GM.dbug.Info(null, "Playlist Built! : " + name);
+		GM.logger.Info(null, "Playlist Built! : " + name);
 	}
 
 	public void BuildPlaylistJSON()

--- a/Assets/Scripts/System/Data/Song.cs
+++ b/Assets/Scripts/System/Data/Song.cs
@@ -10,7 +10,7 @@ public class Song
 	public AudioClip clip;
 
 	public Song(string name, string author, AudioClip clip) {
-		GM.dbug.Info(null, "Creating New Song!");
+		GM.logger.Info(null, "Creating New Song!");
 		this.name = name;
 		this.author = author;
 		this.clip = clip;

--- a/Assets/Scripts/System/Data/Song.cs
+++ b/Assets/Scripts/System/Data/Song.cs
@@ -6,11 +6,11 @@ public class Song
 {
 
 	public string name;
-	public string author;    
+	public string author;
 	public AudioClip clip;
 
 	public Song(string name, string author, AudioClip clip) {
-		GM.dbug.Log(null, "Creating New Song!");
+		GM.dbug.Info(null, "Creating New Song!");
 		this.name = name;
 		this.author = author;
 		this.clip = clip;

--- a/Assets/Scripts/System/GM.cs
+++ b/Assets/Scripts/System/GM.cs
@@ -21,10 +21,6 @@ public class GM : Singleton<GM> {
     public static Jukebox jukebox;
 
     new void Awake() {
-        VersionNumber = versionNumber;
-        Debug.Log("#####  VERSION " + versionNumber + " #####");
-        writeProcessInfo();
-
         Cursor.visible = false;
 
         runner = GetComponent<Runner>();
@@ -34,6 +30,10 @@ public class GM : Singleton<GM> {
         dbug = GetComponent<Dbug>();
         sync = GetComponent<GameSync>();
         logOutput = GetComponent<LogOutputHandler>();
+
+        VersionNumber = versionNumber;
+        GM.dbug.Info("#####  VERSION " + versionNumber + " #####");
+        writeProcessInfo();
 
         //Not 100% sure why the jukebox is here. :S
         if (GameObject.Find("Jukebox"))
@@ -87,7 +87,7 @@ public class GM : Singleton<GM> {
                       "\n" +
                       Path.Combine(Path.GetFullPath("."), "WINNITRON.exe");
 
-        Debug.Log("writing pid and exe path to " + PidFile());
+        GM.dbug.Debug("writing pid and exe path to " + PidFile());
         File.WriteAllText(PidFile(), info);
     }
 

--- a/Assets/Scripts/System/GM.cs
+++ b/Assets/Scripts/System/GM.cs
@@ -14,7 +14,7 @@ public class GM : Singleton<GM> {
     public static DataManager data;
     public static OptionsManager options;
     public static StateManager state;
-    public static Dbug dbug;
+    public static Logger logger;
     public static GameSync sync;
     public static LogOutputHandler logOutput;
 
@@ -27,12 +27,12 @@ public class GM : Singleton<GM> {
         data = GetComponent<DataManager> ();
         options = GetComponent<OptionsManager> ();
         state = GetComponent<StateManager> ();
-        dbug = GetComponent<Dbug>();
+        logger = GetComponent<Logger>();
         sync = GetComponent<GameSync>();
         logOutput = GetComponent<LogOutputHandler>();
 
         VersionNumber = versionNumber;
-        GM.dbug.Info("#####  VERSION " + versionNumber + " #####");
+        GM.logger.Info("#####  VERSION " + versionNumber + " #####");
         writeProcessInfo();
 
         //Not 100% sure why the jukebox is here. :S
@@ -87,7 +87,7 @@ public class GM : Singleton<GM> {
                       "\n" +
                       Path.Combine(Path.GetFullPath("."), "WINNITRON.exe");
 
-        GM.dbug.Debug("writing pid and exe path to " + PidFile());
+        GM.logger.Debug("writing pid and exe path to " + PidFile());
         File.WriteAllText(PidFile(), info);
     }
 

--- a/Assets/Scripts/System/GM.cs
+++ b/Assets/Scripts/System/GM.cs
@@ -44,6 +44,11 @@ public class GM : Singleton<GM> {
     }
 
 
+    void OnApplicationQuit()
+    {
+        File.Delete(PidFile());
+    }
+
     /// <summary>
     /// Causes an Oops screen to appear.  This function calls the real Oops in StateManager.cs
     /// </summary>
@@ -78,16 +83,12 @@ public class GM : Singleton<GM> {
     }
 
     private void writeProcessInfo() {
-        string drive = Environment.GetEnvironmentVariable("HOMEDRIVE");
-        string path = Environment.GetEnvironmentVariable("HOMEPATH");
-        string pidFile = Path.Combine(Path.Combine(drive, path), "winnitron.pid");
-
         string info = System.Diagnostics.Process.GetCurrentProcess().Id +
                       "\n" +
                       Path.Combine(Path.GetFullPath("."), "WINNITRON.exe");
 
-        Debug.Log("writing pid and exe path to " + pidFile);
-        File.WriteAllText(pidFile, info);
+        Debug.Log("writing pid and exe path to " + PidFile());
+        File.WriteAllText(PidFile(), info);
     }
 
 
@@ -107,9 +108,21 @@ public class GM : Singleton<GM> {
         Screen.fullScreen = true;
     }
 
+    public static string PidFile() {
+        string drive = Environment.GetEnvironmentVariable("HOMEDRIVE");
+        string path = Environment.GetEnvironmentVariable("HOMEPATH");
+
+        return Path.Combine(Path.Combine(drive, path), "winnitron.pid");
+    }
+
     #else
 
     public static void ResetScreen() {
+    }
+
+    public static string PidFile() {
+        string path = Environment.GetEnvironmentVariable("HOME");
+        return Path.Combine(path, "winnitron.pid");
     }
 
     #endif

--- a/Assets/Scripts/System/GameSync.cs
+++ b/Assets/Scripts/System/GameSync.cs
@@ -59,7 +59,7 @@ public class GameSync : MonoBehaviour {
     {
         if (syncType != SyncType.NONE)
         {
-            GM.dbug.Log(this, "GameSync: Running Sync...");
+            GM.dbug.Info(this, "GameSync: Running Sync...");
             SyncText("INITIALIZING SYNC!");
 
             initConfig();
@@ -69,7 +69,7 @@ public class GameSync : MonoBehaviour {
 
         else
         {
-            GM.dbug.Log(this, "GameSync: Skipping Sync...");
+            GM.dbug.Info(this, "GameSync: Skipping Sync...");
             EndSync();
         }
     }
@@ -88,7 +88,7 @@ public class GameSync : MonoBehaviour {
         yield return www;
 
         if (www.error == null) {
-            GM.dbug.Log(this, "fetched playlists: " + www.text);
+            GM.dbug.Info(this, "fetched playlists: " + www.text);
             var data = JSON.Parse(www.text);
             foreach (JSONNode playlist_data in data["playlists"].AsArray) {
                 playlists.Add(new Playlist(playlist_data, games_dir));
@@ -98,7 +98,7 @@ public class GameSync : MonoBehaviour {
             SluggedItem.deleteExtraDirectories(games_dir, playlists);
 
             foreach(Playlist playlist in playlists) {
-                GM.dbug.Log(this, "creating " + playlist.parentDirectory);
+                GM.dbug.Info(this, "creating " + playlist.parentDirectory);
 
                 SyncText("Initializing playlist " + playlist.title);
 
@@ -110,7 +110,7 @@ public class GameSync : MonoBehaviour {
                 // since the last sync.
                 ArrayList gamesToDownload = playlist.gamesToDownload();
                 foreach (Game game in gamesToDownload) {
-                    GM.dbug.Log(this, "Downloading: " + game.title);
+                    GM.dbug.Info(this, "Downloading: " + game.title);
 
                     //Start the downloadin'!
 
@@ -129,7 +129,7 @@ public class GameSync : MonoBehaviour {
                     if (!string.IsNullOrEmpty(download.error))
                     {
                         // error!
-                        Debug.LogError("Error downloading '" + download.url + "': " + download.error);
+                        GM.dbug.Error("Error downloading '" + download.url + "': " + download.error);
                         yield return SyncText("Error downloading " + game.title + "!", 3);
                     }
                     else
@@ -175,7 +175,7 @@ public class GameSync : MonoBehaviour {
             EndSync();
 
         } else {
-            Debug.LogError("Error fetching playlists: " + www.error);
+            GM.dbug.Error("Error fetching playlists: " + www.error);
             GM.Oops(GM.options.GetText("error", "fetchPlaylistError"));
         }
     }
@@ -187,7 +187,7 @@ public class GameSync : MonoBehaviour {
     private void EndSync()
     {
         lastUpdate = DateTime.Now;
-        GM.dbug.Log(this, "GameSync: Sync complete at " + lastUpdate.ToString());
+        GM.dbug.Info(this, "GameSync: Sync complete at " + lastUpdate.ToString());
 
         //Just double check the the proper data is loaded
         GM.data.ReloadData();
@@ -243,10 +243,8 @@ public class GameSync : MonoBehaviour {
             foreach (string dirFullPath in installed) {
                 string directory = new DirectoryInfo(dirFullPath).Name;
 
-                //Debug.Log("checking " + directory + " for deletion...");
-
                 if (SluggedItem.directoryIsDeletable(directory, keepers)) {
-                    Debug.Log("deleting " + dirFullPath);
+                    GM.dbug.Info("deleting " + dirFullPath);
                     Directory.Delete(dirFullPath, true);
                 }
             }
@@ -284,7 +282,7 @@ public class GameSync : MonoBehaviour {
         }
 
         public ArrayList gamesToDownload() {
-            Debug.Log("Syncing games for playlist '" + title + "'");
+            GM.dbug.Info("Syncing games for playlist '" + title + "'");
 
 
             ArrayList toInstall = new ArrayList();
@@ -296,7 +294,7 @@ public class GameSync : MonoBehaviour {
                 }
 
                 if (!game.alreadyInstalled() || game.lastModified > installModified) {
-                    Debug.Log("Gonna install " + game.title);
+                    GM.dbug.Info("Gonna install " + game.title);
                     toInstall.Add(game);
                 }
             }
@@ -348,7 +346,6 @@ public class GameSync : MonoBehaviour {
 
 
         public bool alreadyInstalled() {
-            //Debug.Log("checking for installation: " + installDirectory);
             return File.Exists(Path.Combine(installDirectory, "winnitron_metadata.json"));
         }
 
@@ -369,7 +366,6 @@ public class GameSync : MonoBehaviour {
             installationMetadata.Add("keys", keymap);
 
             string filename = Path.Combine(installDirectory, "winnitron_metadata.json");
-            // Debug.Log("writing to " + filename + ": " + installationMetadata.ToString());
             System.IO.File.WriteAllText(filename, installationMetadata.ToString());
         }
     }

--- a/Assets/Scripts/System/GameSync.cs
+++ b/Assets/Scripts/System/GameSync.cs
@@ -59,7 +59,7 @@ public class GameSync : MonoBehaviour {
     {
         if (syncType != SyncType.NONE)
         {
-            GM.dbug.Info(this, "GameSync: Running Sync...");
+            GM.logger.Info(this, "GameSync: Running Sync...");
             SyncText("INITIALIZING SYNC!");
 
             initConfig();
@@ -69,7 +69,7 @@ public class GameSync : MonoBehaviour {
 
         else
         {
-            GM.dbug.Info(this, "GameSync: Skipping Sync...");
+            GM.logger.Info(this, "GameSync: Skipping Sync...");
             EndSync();
         }
     }
@@ -88,7 +88,7 @@ public class GameSync : MonoBehaviour {
         yield return www;
 
         if (www.error == null) {
-            GM.dbug.Info(this, "fetched playlists: " + www.text);
+            GM.logger.Info(this, "fetched playlists: " + www.text);
             var data = JSON.Parse(www.text);
             foreach (JSONNode playlist_data in data["playlists"].AsArray) {
                 playlists.Add(new Playlist(playlist_data, games_dir));
@@ -98,7 +98,7 @@ public class GameSync : MonoBehaviour {
             SluggedItem.deleteExtraDirectories(games_dir, playlists);
 
             foreach(Playlist playlist in playlists) {
-                GM.dbug.Info(this, "creating " + playlist.parentDirectory);
+                GM.logger.Info(this, "creating " + playlist.parentDirectory);
 
                 SyncText("Initializing playlist " + playlist.title);
 
@@ -110,7 +110,7 @@ public class GameSync : MonoBehaviour {
                 // since the last sync.
                 ArrayList gamesToDownload = playlist.gamesToDownload();
                 foreach (Game game in gamesToDownload) {
-                    GM.dbug.Info(this, "Downloading: " + game.title);
+                    GM.logger.Info(this, "Downloading: " + game.title);
 
                     //Start the downloadin'!
 
@@ -129,7 +129,7 @@ public class GameSync : MonoBehaviour {
                     if (!string.IsNullOrEmpty(download.error))
                     {
                         // error!
-                        GM.dbug.Error("Error downloading '" + download.url + "': " + download.error);
+                        GM.logger.Error("Error downloading '" + download.url + "': " + download.error);
                         yield return SyncText("Error downloading " + game.title + "!", 3);
                     }
                     else
@@ -175,7 +175,7 @@ public class GameSync : MonoBehaviour {
             EndSync();
 
         } else {
-            GM.dbug.Error("Error fetching playlists: " + www.error);
+            GM.logger.Error("Error fetching playlists: " + www.error);
             GM.Oops(GM.options.GetText("error", "fetchPlaylistError"));
         }
     }
@@ -187,7 +187,7 @@ public class GameSync : MonoBehaviour {
     private void EndSync()
     {
         lastUpdate = DateTime.Now;
-        GM.dbug.Info(this, "GameSync: Sync complete at " + lastUpdate.ToString());
+        GM.logger.Info(this, "GameSync: Sync complete at " + lastUpdate.ToString());
 
         //Just double check the the proper data is loaded
         GM.data.ReloadData();
@@ -244,7 +244,7 @@ public class GameSync : MonoBehaviour {
                 string directory = new DirectoryInfo(dirFullPath).Name;
 
                 if (SluggedItem.directoryIsDeletable(directory, keepers)) {
-                    GM.dbug.Info("deleting " + dirFullPath);
+                    GM.logger.Info("deleting " + dirFullPath);
                     Directory.Delete(dirFullPath, true);
                 }
             }
@@ -282,7 +282,7 @@ public class GameSync : MonoBehaviour {
         }
 
         public ArrayList gamesToDownload() {
-            GM.dbug.Info("Syncing games for playlist '" + title + "'");
+            GM.logger.Info("Syncing games for playlist '" + title + "'");
 
 
             ArrayList toInstall = new ArrayList();
@@ -294,7 +294,7 @@ public class GameSync : MonoBehaviour {
                 }
 
                 if (!game.alreadyInstalled() || game.lastModified > installModified) {
-                    GM.dbug.Info("Gonna install " + game.title);
+                    GM.logger.Info("Gonna install " + game.title);
                     toInstall.Add(game);
                 }
             }

--- a/Assets/Scripts/System/KeyTranslator.cs
+++ b/Assets/Scripts/System/KeyTranslator.cs
@@ -8,7 +8,7 @@ public class KeyTranslator {
 
     public KeyTranslator(string optionsPath) {
         string file = Path.Combine(optionsPath, "key_translation.json");
-        GM.dbug.Debug("KEY TRANSLATION FILE: " + file);
+        GM.logger.Debug("KEY TRANSLATION FILE: " + file);
         translation = GM.data.LoadJson(file)["keys"].AsArray;
     }
 

--- a/Assets/Scripts/System/KeyTranslator.cs
+++ b/Assets/Scripts/System/KeyTranslator.cs
@@ -8,7 +8,7 @@ public class KeyTranslator {
 
     public KeyTranslator(string optionsPath) {
         string file = Path.Combine(optionsPath, "key_translation.json");
-        Debug.Log("KEY TRANSLATION FILE: " + file);
+        GM.dbug.Debug("KEY TRANSLATION FILE: " + file);
         translation = GM.data.LoadJson(file)["keys"].AsArray;
     }
 

--- a/Assets/Scripts/System/Managers/DataManager.cs
+++ b/Assets/Scripts/System/Managers/DataManager.cs
@@ -28,7 +28,7 @@ public class DataManager : Singleton<DataManager>  {
         //Call the delegate and all methods hooked in
         //Primarily used in LauncherUIController.cs to update the data model
         //But could be used elsewhere
-        GM.dbug.Log(this, "DataManager: finished updating data.");
+        GM.dbug.Info(this, "DataManager: finished updating data.");
 
         OnDataUpdated();
 	}
@@ -61,16 +61,16 @@ public class DataManager : Singleton<DataManager>  {
         var info = new DirectoryInfo(GM.options.musicPath);
         var songFiles = info.GetFiles();
 
-        GM.dbug.Log(this, "JUKEBOX: Started Loading Song Files.");
+        GM.dbug.Info(this, "JUKEBOX: Started Loading Song Files.");
 
         foreach (var song in songFiles)
         {
             var fileExt = song.FullName.Substring(Mathf.Max(0, song.FullName.Length - 4));
-            GM.dbug.Log(this, "JUKEBOX: song extension is " + fileExt);
+            GM.dbug.Info(this, "JUKEBOX: song extension is " + fileExt);
 
             if (song.Name.Substring(0, 1) != "." && fileExt == ".ogg")
             {
-                GM.dbug.Log(this, "JUKEBOX: Started loading " + song.FullName);
+                GM.dbug.Info(this, "JUKEBOX: Started loading " + song.FullName);
 
                 WWW audioLoader = new WWW("file://" + song.FullName);
 
@@ -88,13 +88,13 @@ public class DataManager : Singleton<DataManager>  {
                 var author = words[1];
 
                 //We're done!
-                GM.dbug.Log(this, "JUKEBOX: Can load song: " + audioLoader.GetAudioClip(false));
+                GM.dbug.Info(this, "JUKEBOX: Can load song: " + audioLoader.GetAudioClip(false));
                 songs.Add(new Song(name, author, audioLoader.GetAudioClip(false)));
-                GM.dbug.Log(this, "JUKEBOX: Done loading " + song.FullName);
+                GM.dbug.Info(this, "JUKEBOX: Done loading " + song.FullName);
             }
             else
             {
-                GM.dbug.Log(this, "JUKEBOX: Skipped " + song.FullName + " // not an .ogg");
+                GM.dbug.Warn(this, "JUKEBOX: Skipped " + song.FullName + " // not an .ogg");
             }
         }
     }
@@ -114,7 +114,7 @@ public class DataManager : Singleton<DataManager>  {
 		}
 		catch
 		{
-			Debug.Log("Error loading JSON file: " + fileLocation);
+			GM.dbug.Error("Error loading JSON file: " + fileLocation);
 			GM.Oops (GM.Text("error", "cannotFindJson"));
 			return null;
 		}

--- a/Assets/Scripts/System/Managers/DataManager.cs
+++ b/Assets/Scripts/System/Managers/DataManager.cs
@@ -28,7 +28,7 @@ public class DataManager : Singleton<DataManager>  {
         //Call the delegate and all methods hooked in
         //Primarily used in LauncherUIController.cs to update the data model
         //But could be used elsewhere
-        GM.dbug.Info(this, "DataManager: finished updating data.");
+        GM.logger.Info(this, "DataManager: finished updating data.");
 
         OnDataUpdated();
 	}
@@ -61,16 +61,16 @@ public class DataManager : Singleton<DataManager>  {
         var info = new DirectoryInfo(GM.options.musicPath);
         var songFiles = info.GetFiles();
 
-        GM.dbug.Info(this, "JUKEBOX: Started Loading Song Files.");
+        GM.logger.Info(this, "JUKEBOX: Started Loading Song Files.");
 
         foreach (var song in songFiles)
         {
             var fileExt = song.FullName.Substring(Mathf.Max(0, song.FullName.Length - 4));
-            GM.dbug.Info(this, "JUKEBOX: song extension is " + fileExt);
+            GM.logger.Info(this, "JUKEBOX: song extension is " + fileExt);
 
             if (song.Name.Substring(0, 1) != "." && fileExt == ".ogg")
             {
-                GM.dbug.Info(this, "JUKEBOX: Started loading " + song.FullName);
+                GM.logger.Info(this, "JUKEBOX: Started loading " + song.FullName);
 
                 WWW audioLoader = new WWW("file://" + song.FullName);
 
@@ -88,13 +88,13 @@ public class DataManager : Singleton<DataManager>  {
                 var author = words[1];
 
                 //We're done!
-                GM.dbug.Info(this, "JUKEBOX: Can load song: " + audioLoader.GetAudioClip(false));
+                GM.logger.Info(this, "JUKEBOX: Can load song: " + audioLoader.GetAudioClip(false));
                 songs.Add(new Song(name, author, audioLoader.GetAudioClip(false)));
-                GM.dbug.Info(this, "JUKEBOX: Done loading " + song.FullName);
+                GM.logger.Info(this, "JUKEBOX: Done loading " + song.FullName);
             }
             else
             {
-                GM.dbug.Warn(this, "JUKEBOX: Skipped " + song.FullName + " // not an .ogg");
+                GM.logger.Warn(this, "JUKEBOX: Skipped " + song.FullName + " // not an .ogg");
             }
         }
     }
@@ -114,7 +114,7 @@ public class DataManager : Singleton<DataManager>  {
 		}
 		catch
 		{
-			GM.dbug.Error("Error loading JSON file: " + fileLocation);
+			GM.logger.Error("Error loading JSON file: " + fileLocation);
 			GM.Oops (GM.Text("error", "cannotFindJson"));
 			return null;
 		}

--- a/Assets/Scripts/System/Managers/OptionsManager.cs
+++ b/Assets/Scripts/System/Managers/OptionsManager.cs
@@ -158,11 +158,33 @@ public class OptionsManager : MonoBehaviour {
 
         //Load that JSON
         GM.logger.Info("Loading options from " + optionsFile);
-        GM.logger.Info("Options file exists: " + System.IO.File.Exists(optionsFile));
+        GM.logger.Debug("Options file exists: " + System.IO.File.Exists(optionsFile));
 
         if (System.IO.File.Exists(optionsFile))
         {
             O = GM.data.LoadJson(optionsFile);
+
+            logger = O["logger"];
+            switch(logger["level"]) {
+                case "debug":
+                    Logger.logLevel = Logger.LogLevels.Debug;
+                    break;
+                case "info":
+                case null:
+                    Logger.logLevel = Logger.LogLevels.Info;
+                    break;
+                case "warn":
+                    Logger.logLevel = Logger.LogLevels.Warn;
+                    break;
+                case "error":
+                    Logger.logLevel = Logger.LogLevels.Error;
+                    break;
+                default:
+                    Logger.logLevel = Logger.LogLevels.Info;
+                    GM.logger.Warn("Invalid log level '" + logger["level"] + "'. Setting to default 'info'. Valid values are 'debug', 'info', 'warn', 'error'.");
+                    break;
+            }
+
             SetKeys();
 
             //Launcher Settings
@@ -204,8 +226,6 @@ public class OptionsManager : MonoBehaviour {
             GM.logger.Info(this, "OPTIONS: Time to Update is " + GM.sync.timeToUpdate.ToString());
 
             GM.sync.syncOnStartup = O["sync"]["syncOnStartup"].AsBool;
-
-            logger = O["logger"];
 
             // Tell GM that Options is done with all the Init stuff
             initializing = false;

--- a/Assets/Scripts/System/Managers/OptionsManager.cs
+++ b/Assets/Scripts/System/Managers/OptionsManager.cs
@@ -62,7 +62,7 @@ public class KeyBindings {
             }
 
             if (allKeys().Contains(key)) {
-                GM.dbug.Error("Duplicate key found: " + key);
+                GM.logger.Error("Duplicate key found: " + key);
                 GM.Oops(GM.Text("error", "invalidKeymap"), true);
             }
         } catch (KeyNotFoundException) {
@@ -139,11 +139,11 @@ public class OptionsManager : MonoBehaviour {
         optionsPath = defaultOptionsPath;
         keyTranslator = new KeyTranslator(defaultOptionsPath);
 
-        GM.dbug.Info("DEFAULT OPTIONS PATH:" + optionsPath);
+        GM.logger.Info("DEFAULT OPTIONS PATH:" + optionsPath);
 
         // Figure out where the Options are by reading the .json in Options file
         string userdataFile = Path.Combine(optionsPath, "winnitron_userdata_path.json");
-        GM.dbug.Info("reading userdata location from " + userdataFile);
+        GM.logger.Info("reading userdata location from " + userdataFile);
         if (System.IO.File.Exists(userdataFile))
         {
             dataPath = GM.data.LoadJson(userdataFile)["userDataPath"];
@@ -151,14 +151,14 @@ public class OptionsManager : MonoBehaviour {
             GM.Oops(GM.Text("error", "cannotFindUserDataPathJson"), true);
         }
 
-        GM.dbug.Info("DATA PATH:" + dataPath);
+        GM.logger.Info("DATA PATH:" + dataPath);
         optionsPath = Path.Combine(dataPath, "Options");
-        GM.dbug.Info("CONFIGURED OPTIONS PATH:" + optionsPath);
+        GM.logger.Info("CONFIGURED OPTIONS PATH:" + optionsPath);
         string optionsFile = Path.Combine(optionsPath, "winnitron_options.json");
 
         //Load that JSON
-        GM.dbug.Info("Loading options from " + optionsFile);
-        GM.dbug.Info("Options file exists: " + System.IO.File.Exists(optionsFile));
+        GM.logger.Info("Loading options from " + optionsFile);
+        GM.logger.Info("Options file exists: " + System.IO.File.Exists(optionsFile));
 
         if (System.IO.File.Exists(optionsFile))
         {
@@ -166,7 +166,7 @@ public class OptionsManager : MonoBehaviour {
             SetKeys();
 
             //Launcher Settings
-            GM.dbug.Info(this, "OPTIONS:" + O.ToString());
+            GM.logger.Info(this, "OPTIONS:" + O.ToString());
             if (O["launcher"]["widescreen"] != null) widescreen = O["launcher"]["widescreen"].AsBool;
             if (O["launcher"]["idleTimeBeforeAttract"] != null) launcherIdleTimeBeforeAttract = O["launcher"]["idleTimeBeforeAttract"].AsInt;
 
@@ -184,14 +184,14 @@ public class OptionsManager : MonoBehaviour {
             if (O["launcher"]["language"] != null)
             {
                 string langFile = Path.Combine(optionsPath, "winnitron_text_" + O["launcher"]["language"] + ".json");
-                GM.dbug.Info(this, "LANGUAGE FILE: " + langFile);
+                GM.logger.Info(this, "LANGUAGE FILE: " + langFile);
                 language = GM.data.LoadJson(langFile);
             }
 
             //Sync Options
             var mode = O["sync"]["type"].Value.ToLower();
 
-            GM.dbug.Info(this, "SYNCMODE " + mode);
+            GM.logger.Info(this, "SYNCMODE " + mode);
 
             if (mode == "local" || mode == "localonly" || mode == "none")
                 GM.sync.syncType = GameSync.SyncType.NONE;
@@ -201,7 +201,7 @@ public class OptionsManager : MonoBehaviour {
                 GM.sync.syncType = GameSync.SyncType.ALWAYS;
 
             GM.sync.timeToUpdate = new TimeSpan(O["sync"]["dailySyncTime"]["hour"].AsInt, O["sync"]["dailySyncTime"]["minute"].AsInt, 0);
-            GM.dbug.Info(this, "OPTIONS: Time to Update is " + GM.sync.timeToUpdate.ToString());
+            GM.logger.Info(this, "OPTIONS: Time to Update is " + GM.sync.timeToUpdate.ToString());
 
             GM.sync.syncOnStartup = O["sync"]["syncOnStartup"].AsBool;
 
@@ -235,7 +235,7 @@ public class OptionsManager : MonoBehaviour {
         if (path.ToString().Contains("default"))
             path = Path.Combine(dataPath, dirName);
 
-        GM.dbug.Info(this, "OPTIONS: " + dirName + " path is " + path);
+        GM.logger.Info(this, "OPTIONS: " + dirName + " path is " + path);
 
         if (!Directory.Exists(path))
         {
@@ -260,7 +260,7 @@ public class OptionsManager : MonoBehaviour {
                 if (player[control] != null) {
                     KeyCode customKey = keyTranslator.fromAHK(player[control]);
                     keys.SetKey(pNum, control, customKey);
-                    GM.dbug.Debug("CUSTOM KEY (player " + pNum + " " + control + "): " + customKey);
+                    GM.logger.Debug("CUSTOM KEY (player " + pNum + " " + control + "): " + customKey);
                 }
             }
         }

--- a/Assets/Scripts/System/Managers/OptionsManager.cs
+++ b/Assets/Scripts/System/Managers/OptionsManager.cs
@@ -55,14 +55,14 @@ public class KeyBindings {
 
 
     public void SetKey(int playerNum, string control, KeyCode key) {
-       
+
         try {
             if (keymap[playerNum - 1][control] == key) {
                 return; // nothing to do here.
             }
 
             if (allKeys().Contains(key)) {
-                Debug.Log("Duplicate key found: " + key);
+                GM.dbug.Error("Duplicate key found: " + key);
                 GM.Oops(GM.Text("error", "invalidKeymap"), true);
             }
         } catch (KeyNotFoundException) {
@@ -139,11 +139,11 @@ public class OptionsManager : MonoBehaviour {
         optionsPath = defaultOptionsPath;
         keyTranslator = new KeyTranslator(defaultOptionsPath);
 
-        Debug.Log("DEFAULT OPTIONS PATH:" + optionsPath);
+        GM.dbug.Info("DEFAULT OPTIONS PATH:" + optionsPath);
 
         // Figure out where the Options are by reading the .json in Options file
         string userdataFile = Path.Combine(optionsPath, "winnitron_userdata_path.json");
-        Debug.Log("reading userdata location from " + userdataFile);
+        GM.dbug.Info("reading userdata location from " + userdataFile);
         if (System.IO.File.Exists(userdataFile))
         {
             dataPath = GM.data.LoadJson(userdataFile)["userDataPath"];
@@ -151,14 +151,14 @@ public class OptionsManager : MonoBehaviour {
             GM.Oops(GM.Text("error", "cannotFindUserDataPathJson"), true);
         }
 
-        Debug.Log("DATA PATH:" + dataPath);
+        GM.dbug.Info("DATA PATH:" + dataPath);
         optionsPath = Path.Combine(dataPath, "Options");
-        Debug.Log("CONFIGURED OPTIONS PATH:" + optionsPath);
+        GM.dbug.Info("CONFIGURED OPTIONS PATH:" + optionsPath);
         string optionsFile = Path.Combine(optionsPath, "winnitron_options.json");
 
         //Load that JSON
-        Debug.Log("Loading options from " + optionsFile);
-        Debug.Log("Options file exists: " + System.IO.File.Exists(optionsFile));
+        GM.dbug.Info("Loading options from " + optionsFile);
+        GM.dbug.Info("Options file exists: " + System.IO.File.Exists(optionsFile));
 
         if (System.IO.File.Exists(optionsFile))
         {
@@ -166,7 +166,7 @@ public class OptionsManager : MonoBehaviour {
             SetKeys();
 
             //Launcher Settings
-            GM.dbug.Log(this, "O:" + O.ToString());
+            GM.dbug.Info(this, "OPTIONS:" + O.ToString());
             if (O["launcher"]["widescreen"] != null) widescreen = O["launcher"]["widescreen"].AsBool;
             if (O["launcher"]["idleTimeBeforeAttract"] != null) launcherIdleTimeBeforeAttract = O["launcher"]["idleTimeBeforeAttract"].AsInt;
 
@@ -184,14 +184,14 @@ public class OptionsManager : MonoBehaviour {
             if (O["launcher"]["language"] != null)
             {
                 string langFile = Path.Combine(optionsPath, "winnitron_text_" + O["launcher"]["language"] + ".json");
-                GM.dbug.Log(this, "LANGUAGE FILE: " + langFile);
+                GM.dbug.Info(this, "LANGUAGE FILE: " + langFile);
                 language = GM.data.LoadJson(langFile);
             }
 
             //Sync Options
             var mode = O["sync"]["type"].Value.ToLower();
 
-            GM.dbug.Log(this, "SYNCMODE " + mode);
+            GM.dbug.Info(this, "SYNCMODE " + mode);
 
             if (mode == "local" || mode == "localonly" || mode == "none")
                 GM.sync.syncType = GameSync.SyncType.NONE;
@@ -201,7 +201,7 @@ public class OptionsManager : MonoBehaviour {
                 GM.sync.syncType = GameSync.SyncType.ALWAYS;
 
             GM.sync.timeToUpdate = new TimeSpan(O["sync"]["dailySyncTime"]["hour"].AsInt, O["sync"]["dailySyncTime"]["minute"].AsInt, 0);
-            GM.dbug.Log(this, "OPTIONS: Time to Update is " + GM.sync.timeToUpdate.ToString());
+            GM.dbug.Info(this, "OPTIONS: Time to Update is " + GM.sync.timeToUpdate.ToString());
 
             GM.sync.syncOnStartup = O["sync"]["syncOnStartup"].AsBool;
 
@@ -235,7 +235,7 @@ public class OptionsManager : MonoBehaviour {
         if (path.ToString().Contains("default"))
             path = Path.Combine(dataPath, dirName);
 
-        GM.dbug.Log(this, "OPTIONS: " + dirName + " path is " + path);
+        GM.dbug.Info(this, "OPTIONS: " + dirName + " path is " + path);
 
         if (!Directory.Exists(path))
         {
@@ -260,7 +260,7 @@ public class OptionsManager : MonoBehaviour {
                 if (player[control] != null) {
                     KeyCode customKey = keyTranslator.fromAHK(player[control]);
                     keys.SetKey(pNum, control, customKey);
-                    Debug.Log("CUSTOM KEY (player " + pNum + " " + control + "): " + customKey);
+                    GM.dbug.Debug("CUSTOM KEY (player " + pNum + " " + control + "): " + customKey);
                 }
             }
         }

--- a/Assets/Scripts/System/Managers/StateManager.cs
+++ b/Assets/Scripts/System/Managers/StateManager.cs
@@ -67,7 +67,7 @@ public class StateManager : MonoBehaviour {
 
 		foreach (var state in states) {
 			if (newState == state.worldState) {
-				GM.dbug.Info(this, "STATE: activating state " + state.worldState);
+				GM.logger.Debug(this, "STATE: activating state " + state.worldState);
 				state.Activate();
 				worldState = state.worldState;
 			}
@@ -75,7 +75,7 @@ public class StateManager : MonoBehaviour {
 				state.Deactivate();
 		}
 
-        GM.dbug.Info(this, "STATE: new state is " + worldState);
+        GM.logger.Debug(this, "STATE: new state is " + worldState);
 
         GM.ResetScreen();
 	}

--- a/Assets/Scripts/System/Managers/StateManager.cs
+++ b/Assets/Scripts/System/Managers/StateManager.cs
@@ -28,7 +28,7 @@ public class StateManager : MonoBehaviour {
         //Wait for options script to get all the folders before continuing
         while (GM.options.initializing) yield return null;
 
-		foreach (State state in states) 
+		foreach (State state in states)
 			state.gameObject.SetActive (true);
 
         //This just changes the state to the first state that's in the inspector
@@ -41,7 +41,7 @@ public class StateManager : MonoBehaviour {
         }
 	}
 
-	void Update () {
+	void Update() {
 
 		//DEBUG KEYS
 		//Switch states for testing.  These keys aren't used on Winnitrons yet
@@ -60,22 +60,22 @@ public class StateManager : MonoBehaviour {
 	}
 
     /// <summary>
-    /// Change the state of the Launcher.  
+    /// Change the state of the Launcher.
     /// </summary>
     /// <param name="newState">Uses StateManager.WorldState enums.</param>
     public void ChangeState(WorldState newState) {
 
 		foreach (var state in states) {
 			if (newState == state.worldState) {
-				GM.dbug.Log (this, "STATE: activating state " + state.worldState);
-				state.Activate ();
+				GM.dbug.Info(this, "STATE: activating state " + state.worldState);
+				state.Activate();
 				worldState = state.worldState;
 			}
 			else
-				state.Deactivate ();
+				state.Deactivate();
 		}
 
-        GM.dbug.Log(this, "STATE: new state is " + worldState);
+        GM.dbug.Info(this, "STATE: new state is " + worldState);
 
         GM.ResetScreen();
 	}

--- a/Assets/Scripts/System/Runner.cs
+++ b/Assets/Scripts/System/Runner.cs
@@ -19,18 +19,15 @@ public class Runner : MonoBehaviour {
         //Store the legacyController in the Awake
         gameRunner = new Process();
         gameRunner.StartInfo.FileName = rungame;
-        GM.dbug.Log(this, "gameRunner path " + gameRunner.StartInfo.FileName);
+        GM.dbug.Info(this, "gameRunner path " + gameRunner.StartInfo.FileName);
 
         if(gameRunner == null)
             GM.Oops(GM.Text("error", "noLegacyControlExe"));
     }
 
-
-
-
 	public void Run(Game game) {
 
-        GM.dbug.Log(this, "Running Game " + game.name);
+        GM.dbug.Info(this, "Running Game: " + game.name);
 
         LoadAHKScript(game);
         game.PreRun();
@@ -46,13 +43,13 @@ public class Runner : MonoBehaviour {
 
 		yield return new WaitForSeconds(1.0f);
 
-        GM.dbug.Log(this, "RUNNER: Running game " + process.StartInfo.FileName);
+        // GM.dbug.Info(this, "RUNNER: Running game " + process.StartInfo.FileName);
 
         process.Start();
         process.WaitForExit();
         process.Close();
 
-        GM.dbug.Log(this, "RUNNER: Finished running game " + process.StartInfo.FileName);
+        GM.dbug.Info(this, "RUNNER: Finished running game " + process.StartInfo.FileName);
 
         GM.Restart();
 	}

--- a/Assets/Scripts/System/Runner.cs
+++ b/Assets/Scripts/System/Runner.cs
@@ -19,7 +19,7 @@ public class Runner : MonoBehaviour {
         //Store the legacyController in the Awake
         gameRunner = new Process();
         gameRunner.StartInfo.FileName = rungame;
-        GM.dbug.Info(this, "gameRunner path " + gameRunner.StartInfo.FileName);
+        GM.logger.Info(this, "gameRunner path " + gameRunner.StartInfo.FileName);
 
         if(gameRunner == null)
             GM.Oops(GM.Text("error", "noLegacyControlExe"));
@@ -27,7 +27,7 @@ public class Runner : MonoBehaviour {
 
 	public void Run(Game game) {
 
-        GM.dbug.Info(this, "Running Game: " + game.name);
+        GM.logger.Info(this, "Running Game: " + game.name);
 
         LoadAHKScript(game);
         game.PreRun();
@@ -43,13 +43,13 @@ public class Runner : MonoBehaviour {
 
 		yield return new WaitForSeconds(1.0f);
 
-        // GM.dbug.Info(this, "RUNNER: Running game " + process.StartInfo.FileName);
+        // GM.logger.Info(this, "RUNNER: Running game " + process.StartInfo.FileName);
 
         process.Start();
         process.WaitForExit();
         process.Close();
 
-        GM.dbug.Info(this, "RUNNER: Finished running game " + process.StartInfo.FileName);
+        GM.logger.Info(this, "RUNNER: Finished running game " + process.StartInfo.FileName);
 
         GM.Restart();
 	}

--- a/Assets/Scripts/System/States/State.cs
+++ b/Assets/Scripts/System/States/State.cs
@@ -24,13 +24,13 @@ public class State : MonoBehaviour {
 		foreach(GameObject gameObject in objectsToToggleOnForState) gameObject.SetActive(false);
 		foreach(GameObject gameObject in objectsToToggleOffForState) gameObject.SetActive(true);
 		foreach(Animation anim in animationsToRewind) {
-			GM.dbug.Log(this, anim + " " + gameObject.name);
+			GM.dbug.Debug(this, anim + " " + gameObject.name);
 			anim.Stop();
 			anim.Rewind();
-			GM.dbug.Log(this, "rewinding: " + anim.name);
+			GM.dbug.Debug(this, "rewinding: " + anim.name);
 		}
 		foreach (Canvas canvas in canvasesToToggleActivation) {
-			GM.dbug.Log(this, "deactivating: " + canvas.name);
+			GM.dbug.Debug(this, "deactivating: " + canvas.name);
 			canvas.enabled = false;
 		}
 	}

--- a/Assets/Scripts/System/States/State.cs
+++ b/Assets/Scripts/System/States/State.cs
@@ -24,13 +24,13 @@ public class State : MonoBehaviour {
 		foreach(GameObject gameObject in objectsToToggleOnForState) gameObject.SetActive(false);
 		foreach(GameObject gameObject in objectsToToggleOffForState) gameObject.SetActive(true);
 		foreach(Animation anim in animationsToRewind) {
-			GM.dbug.Debug(this, anim + " " + gameObject.name);
+			GM.logger.Debug(this, anim + " " + gameObject.name);
 			anim.Stop();
 			anim.Rewind();
-			GM.dbug.Debug(this, "rewinding: " + anim.name);
+			GM.logger.Debug(this, "rewinding: " + anim.name);
 		}
 		foreach (Canvas canvas in canvasesToToggleActivation) {
-			GM.dbug.Debug(this, "deactivating: " + canvas.name);
+			GM.logger.Debug(this, "deactivating: " + canvas.name);
 			canvas.enabled = false;
 		}
 	}

--- a/Assets/Scripts/Util/Dbug.cs
+++ b/Assets/Scripts/Util/Dbug.cs
@@ -4,28 +4,73 @@ using System.Collections;
 using System.Collections.Generic;
 
 public class Dbug: MonoBehaviour {
-	
-	public bool globalOn = false;
+
+    public enum LogLevels { Debug, Info, Warn, Error }
+
+    public int logLevel = (int) LogLevels.Debug;
+
+    public bool globalOn = false;
     public bool showNull = false;
     public bool showTimestamps = true;
 
     public List<UnityEngine.Object> supress;
     public List<UnityEngine.Object> show;
 
-    public void Log(string x)
+    public void Log(string msg, LogLevels msgLevel)
     {
-        if (showTimestamps) Debug.Log(DateTime.Now.ToLocalTime().ToString() + " -- " + x);
-        else Debug.Log(x);
+        if ((int) msgLevel < logLevel)
+            return;
+
+        if (showTimestamps) {
+            string timestamp = DateTime.Now.ToLocalTime().ToString();
+            msg = timestamp + " -- " + msg;
+        }
+
+        msg = msgLevel.ToString().ToUpper() + " -- " + msg;
+        UnityEngine.Debug.Log(msg);
     }
 
-	public void Log(UnityEngine.Object mb, string x) 
-	{
+    public void Log(UnityEngine.Object mb, string msg, LogLevels msgLevel)
+    {
         if (CanShow(mb))
-            Log(x);
-	}
+            Log(msg, msgLevel);
+    }
 
-	public void On() { globalOn = true; }
-	public void Off() { globalOn = false; }
+    public void On() { globalOn = true; }
+    public void Off() { globalOn = false; }
+
+
+    public void Debug(string msg) {
+        Log(msg, LogLevels.Debug);
+    }
+
+    public void Debug(UnityEngine.Object mb, string msg) {
+        Log(mb, msg, LogLevels.Debug);
+    }
+
+    public void Info(string msg) {
+        Log(msg, LogLevels.Info);
+    }
+
+    public void Info(UnityEngine.Object mb, string msg) {
+        Log(mb, msg, LogLevels.Info);
+    }
+
+    public void Warn(string msg) {
+        Log(msg, LogLevels.Warn);
+    }
+
+    public void Warn(UnityEngine.Object mb, string msg) {
+        Log(mb, msg, LogLevels.Warn);
+    }
+
+    public void Error(string msg) {
+        Log(msg, LogLevels.Error);
+    }
+
+    public void Error(UnityEngine.Object mb, string msg) {
+        Log(mb, msg, LogLevels.Error);
+    }
 
     private bool CanShow(UnityEngine.Object mb)
     {

--- a/Assets/Scripts/Util/Logger.cs
+++ b/Assets/Scripts/Util/Logger.cs
@@ -7,7 +7,7 @@ public class Logger: MonoBehaviour {
 
     public enum LogLevels { Debug, Info, Warn, Error }
 
-    public static int logLevel = (int) LogLevels.Info;
+    public static LogLevels logLevel = LogLevels.Info;
 
     public bool globalOn = false;
     public bool showNull = false;
@@ -18,7 +18,7 @@ public class Logger: MonoBehaviour {
 
     public void Log(string msg, LogLevels msgLevel)
     {
-        if ((int) msgLevel < logLevel)
+        if ((int) msgLevel < (int) logLevel)
             return;
 
         if (showTimestamps) {

--- a/Assets/Scripts/Util/Logger.cs
+++ b/Assets/Scripts/Util/Logger.cs
@@ -3,11 +3,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-public class Dbug: MonoBehaviour {
+public class Logger: MonoBehaviour {
 
     public enum LogLevels { Debug, Info, Warn, Error }
 
-    public int logLevel = (int) LogLevels.Debug;
+    public static int logLevel = (int) LogLevels.Info;
 
     public bool globalOn = false;
     public bool showNull = false;

--- a/Assets/Scripts/Util/Logger.cs.meta
+++ b/Assets/Scripts/Util/Logger.cs.meta
@@ -1,8 +1,12 @@
 fileFormatVersion: 2
-guid: 2a834322dec9a43bc974594b13148de5
+guid: 267f9bb973d10493ab68be600e565a56
+timeCreated: 1504484594
+licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The output_log.txt file gets spammed with a lot of messages that make it hard to sift through if you're looking for what went wrong with your setup. Add some levels so that one can opt out of (for example) debugging/dev messages, normal state changes, etc.

Levels are `debug`, `info`, `warn`, and `error`. Default is `info`.

So rather than doing this: `GM.dbug.Log("message");` for everything, now:
```c#
GM.logger.Debug("just debuggin'");
GM.logger.Info("launching game: something.exe");
GM.logger.Warn("missing a file but fear not we can recover");
GM.logger.Error("oh no something went wrong!");
```

- [x] update dbug class
- [x] update all the `Log` calls
- [x] make the level configurable