### PR TITLE
Load key bindings from templates

### DIFF
--- a/Assets/Options/keymap_templates.json
+++ b/Assets/Options/keymap_templates.json
@@ -1,0 +1,122 @@
+{
+  "default": {
+    "1": {
+      "up": "Up",
+      "down": "Down",
+      "right": "Right",
+      "left": "Left",
+      "button1": ".",
+      "button2": "/"
+    },
+    "2": {
+      "up": "w",
+      "down": "s",
+      "right": "d",
+      "left": "a",
+      "button1": "`",
+      "button2": "1"
+    },
+    "3": {
+      "up": "i",
+      "down": "k",
+      "right": "l",
+      "left": "j",
+      "button1": "g",
+      "button2": "h"
+    },
+    "4": {
+      "up": "Numpad8",
+      "down": "Numpad5",
+      "right": "Numpad6",
+      "left": "Numpad4",
+      "button1": "Numpad1",
+      "button2": "Numpad2"
+    }
+  },
+  "legacy": {
+    "1": {
+      "up": "Up",
+      "down": "Down",
+      "right": "Right",
+      "left": "Left",
+      "button1": "x",
+      "button2": "z"
+    },
+    "2": {
+      "up": "i",
+      "down": "k",
+      "right": "l",
+      "left": "j",
+      "button1": "n",
+      "button2": "m"
+    },
+    "3": {
+      "up": "i",
+      "down": "k",
+      "right": "l",
+      "left": "j",
+      "button1": "g",
+      "button2": "h"
+    },
+    "4": {
+      "up": "Numpad8",
+      "down": "Numpad5",
+      "right": "Numpad6",
+      "left": "Numpad4",
+      "button1": "Numpad1",
+      "button2": "Numpad2"
+    }
+  },
+  "flash": {
+    "1": {
+      "up": "Up",
+      "down": "Down",
+      "right": "Right",
+      "left": "Left",
+      "button1": "x",
+      "button2": "z"
+    },
+    "2": {
+      "up": "i",
+      "down": "k",
+      "right": "l",
+      "left": "j",
+      "button1": "n",
+      "button2": "m"
+    },
+    "3": {
+      "up": "i",
+      "down": "k",
+      "right": "l",
+      "left": "j",
+      "button1": "g",
+      "button2": "h"
+    },
+    "4": {
+      "up": "Numpad8",
+      "down": "Numpad5",
+      "right": "Numpad6",
+      "left": "Numpad4",
+      "button1": "Numpad1",
+      "button2": "Numpad2"
+    }
+  },
+  "pico8": {
+    "1": {
+      "up": "Up",
+      "down": "Down",
+      "right": "Right",
+      "left": "Left",
+      "button1": "m",
+      "button2": "n"
+    },
+    "2": {
+      "up": "e",
+      "down": "d",
+      "right": "f",
+      "left": "s",
+      "button1": "q",
+      "button2": "w"
+    }
+  }
+}

--- a/Assets/Options/keymap_templates.json.meta
+++ b/Assets/Options/keymap_templates.json.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 401d5c61630e2488aa433161e7d7fece
+timeCreated: 1510109455
+licenseType: Free
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -250,8 +250,6 @@ public class Game
         string keymap = "";
         ArrayList gameKeys = allGameKeys(getKeyBindings());
 
-        GM.logger.Debug("GET KEY BINDINGS (" + name + "): " + getKeyBindings().ToString());
-
         for(int pNum = 1; pNum <= 4; pNum++) {
             JSONNode playerKeys;
 
@@ -297,6 +295,7 @@ public class Game
 
     private JSONNode getKeyBindings() {
         string tmpl = savedMetadata["keys"]["template"];
+        JSONNode bindings = null;
 
         if (tmpl == null) {
             if (savedMetadata["keys"]["bindings"] == null) {
@@ -307,11 +306,10 @@ public class Game
             }
         }
 
-
         switch(tmpl) {
             case "custom":
                 GM.logger.Debug("Loading custom key bindings for " + name);
-                return savedMetadata["keys"]["bindings"];
+                bindings = savedMetadata["keys"]["bindings"];
                 break;
 
             case "default":
@@ -320,7 +318,7 @@ public class Game
             case "pico8":
                 string file = Path.Combine(GM.options.defaultOptionsPath, "keymap_templates.json");
                 GM.logger.Debug("LOADING " + tmpl + " BINDINGS FROM KEY TEMPLATE FILE: " + file);
-                return GM.data.LoadJson(file)[tmpl];
+                bindings = GM.data.LoadJson(file)[tmpl];
                 break;
 
             default:
@@ -329,7 +327,14 @@ public class Game
                 break;
         }
 
-        return null;
+        // Remove controls for players that don't exist.
+        for (int p = savedMetadata["max_players"].AsInt + 1; p <= 4; p++) {
+            bindings.Remove(p.ToString());
+        }
+
+        GM.logger.Debug("GET KEY BINDINGS (" + name + "): " + bindings.ToString());
+        return bindings;
+
     }
 
     /// <summary>

--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -248,13 +248,14 @@ public class Game
 
     private string insertKeyMapping(string ahkFile) {
         string keymap = "";
-        ArrayList gameKeys = allGameKeys(getKeyBindings());
+        JSONNode parsedBindings = getKeyBindings();
+        ArrayList gameKeys = allGameKeys(parsedBindings);
 
         for(int pNum = 1; pNum <= 4; pNum++) {
             JSONNode playerKeys;
 
             try {
-                playerKeys = getKeyBindings()[pNum.ToString()];
+                playerKeys = parsedBindings[pNum.ToString()];
             } catch (System.NullReferenceException) {
                 break;
             }
@@ -297,6 +298,9 @@ public class Game
         string tmpl = savedMetadata["keys"]["template"];
         JSONNode bindings = null;
 
+        string tmplFile = Path.Combine(GM.options.defaultOptionsPath, "keymap_templates.json");
+        JSONNode bindingTemplates = GM.data.LoadJson(tmplFile);
+
         if (tmpl == null) {
             if (savedMetadata["keys"]["bindings"] == null) {
                 GM.logger.Debug("No key binding info provided for " + name + ". Using defaults.");
@@ -316,14 +320,14 @@ public class Game
             case "legacy":
             case "flash":
             case "pico8":
-                string file = Path.Combine(GM.options.defaultOptionsPath, "keymap_templates.json");
-                GM.logger.Debug("LOADING " + tmpl + " BINDINGS FROM KEY TEMPLATE FILE: " + file);
-                bindings = GM.data.LoadJson(file)[tmpl];
+                GM.logger.Debug("Loading " + tmpl + " bindings from tmplFile: " + tmplFile);
+                bindings = bindingTemplates[tmpl];
                 break;
 
             default:
-                GM.logger.Error("Invalid key template type '" + tmpl + "' for " + name);
-                GM.logger.Error("Valid templates are 'default', 'legacy', 'pico8', 'custom'.");
+                GM.logger.Error("Invalid key template type '" + tmpl + "' for " + name + ". (Using default.) Valid templates are 'default', 'legacy', 'pico8', 'custom'.");
+                GM.logger.Debug("Loading " + tmpl + " bindings from tmplFile: " + tmplFile);
+                bindings = bindingTemplates["default"];
                 break;
         }
 
@@ -332,9 +336,7 @@ public class Game
             bindings.Remove(p.ToString());
         }
 
-        GM.logger.Debug("GET KEY BINDINGS (" + name + "): " + bindings.ToString());
         return bindings;
-
     }
 
     /// <summary>

--- a/Assets/Scripts/System/Data/Game.cs
+++ b/Assets/Scripts/System/Data/Game.cs
@@ -248,13 +248,15 @@ public class Game
 
     private string insertKeyMapping(string ahkFile) {
         string keymap = "";
-        ArrayList gameKeys = allGameKeys(savedMetadata["keys"]["bindings"]);
+        ArrayList gameKeys = allGameKeys(getKeyBindings());
+
+        GM.logger.Debug("GET KEY BINDINGS (" + name + "): " + getKeyBindings().ToString());
 
         for(int pNum = 1; pNum <= 4; pNum++) {
             JSONNode playerKeys;
 
             try {
-                playerKeys = savedMetadata["keys"]["bindings"][pNum.ToString()];
+                playerKeys = getKeyBindings()[pNum.ToString()];
             } catch (System.NullReferenceException) {
                 break;
             }
@@ -291,6 +293,43 @@ public class Game
         }
 
         return keys;
+    }
+
+    private JSONNode getKeyBindings() {
+        string tmpl = savedMetadata["keys"]["template"];
+
+        if (tmpl == null) {
+            if (savedMetadata["keys"]["bindings"] == null) {
+                GM.logger.Debug("No key binding info provided for " + name + ". Using defaults.");
+                tmpl = "default";
+            } else {
+                tmpl = "custom";
+            }
+        }
+
+
+        switch(tmpl) {
+            case "custom":
+                GM.logger.Debug("Loading custom key bindings for " + name);
+                return savedMetadata["keys"]["bindings"];
+                break;
+
+            case "default":
+            case "legacy":
+            case "flash":
+            case "pico8":
+                string file = Path.Combine(GM.options.defaultOptionsPath, "keymap_templates.json");
+                GM.logger.Debug("LOADING " + tmpl + " BINDINGS FROM KEY TEMPLATE FILE: " + file);
+                return GM.data.LoadJson(file)[tmpl];
+                break;
+
+            default:
+                GM.logger.Error("Invalid key template type '" + tmpl + "' for " + name);
+                GM.logger.Error("Valid templates are 'default', 'legacy', 'pico8', 'custom'.");
+                break;
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #69 

If a metadata file was missing `keys: bindings: {}`, all keys would be mapped to NOP, even if there's a valid template specified. Load from template in that case.

This was mainly an issue in local games, since Network-synced ones write the bindings to metadata.json regardless.