### PR TITLE
Better playlist management

### DIFF
--- a/Assets/Scripts/System/Data/Playlist.cs
+++ b/Assets/Scripts/System/Data/Playlist.cs
@@ -28,7 +28,7 @@ public class Playlist
     }
 
     public void SetName() {
-        string file = this.directory + "/winnitron_metadata.json";
+        string file = Path.Combine(this.directory.FullName, "winnitron_metadata.json");
         if(System.IO.File.Exists(file)) {
             string json = File.ReadAllText(file);
             JSONNode data = JSONNode.Parse(json);

--- a/Assets/Scripts/System/Data/Playlist.cs
+++ b/Assets/Scripts/System/Data/Playlist.cs
@@ -2,73 +2,60 @@
 using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
+using SimpleJSON;
 
 [System.Serializable]
 public class Playlist
 {
-	public string name;
-	public DirectoryInfo directory;
-	public List<Game> games;
+    public string name;
+    public string description;
+    public DirectoryInfo directory;
+    public List<Game> games;
 
-	/*
-	 *  Playlist Constructor
-	 *
-	 *  Playlist only takes in the directory that the DataManager hands it
-	 *  and builds everything from there
-	 */
-	public Playlist(string directory)
-	{
-		//Find out the name of the directory
-		this.directory = new DirectoryInfo(directory);
-
-        name = this.directory.Name;
-
-        GM.logger.Debug("Playlist: Name before fixes " + name);
-
-        name = name.TrimStart('_');
-        name = name.Replace('_', ' ').Replace('-', ' ');
-
-        //Replace the underscores for a cleaner name
-        name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name);
-
-        GM.logger.Debug("Playlist: Name after fixes " + name);
-
-        //Init the games list
+    /*
+     *  Playlist Constructor
+     *
+     *  Playlist only takes in the directory that the DataManager hands it
+     *  and builds everything from there
+     */
+    public Playlist(string directory) {
+        this.directory = new DirectoryInfo(directory);
         this.games = new List<Game>();
 
-		//Check for the Winnitron Metadata JSON, and use oldschool folder naming if it doesn't exist
-		if (System.IO.File.Exists (this.directory + "winnitron_metadata.json")) {
-			BuildPlaylistJSON ();
-		} else {
-			BuildPlaylist ();
-		}
-	}
+        SetName();
+        BuildGameList();
+        GM.logger.Info(null, "Playlist Built! : " + name);
+    }
+
+    public void SetName() {
+        string file = this.directory + "/winnitron_metadata.json";
+        if(System.IO.File.Exists(file)) {
+            string json = File.ReadAllText(file);
+            JSONNode data = JSONNode.Parse(json);
+            name = data["title"];
+            description = data["description"];
+
+            GM.logger.Debug("Setting playlist name from json: " + file);
+        } else {
+            name = this.directory.Name;
+            name = name.TrimStart('_');
+            name = name.Replace('_', ' ').Replace('-', ' ');
+            name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name);
+
+            GM.logger.Debug("Playlist metadata file not found: " + file);
+            GM.logger.Debug("Setting playlist name from directory: " + name);
+        }
+    }
 
 
-
-
-	//Where the magic happens
-	public void BuildPlaylist()
-	{
-		foreach (var gameDir in directory.GetDirectories())
-		{
-			//Don't pick any directories that start with a dot
-			if(!gameDir.Name.Substring(0, 1).Equals("."))
-			{
-				//Make a new game
-				Game newGame = new Game(gameDir.FullName);
-
-				//Add a game!  Pass the Game constructor the directory where the game is contained
-				games.Add(newGame);
-			}
-		}
-
-		GM.logger.Info(null, "Playlist Built! : " + name);
-	}
-
-	public void BuildPlaylistJSON()
-	{
-
-	}
+    public void BuildGameList() {
+        foreach(var gameDir in directory.GetDirectories()) {
+            //Don't pick any directories that start with a dot
+            if(!gameDir.Name.Substring(0, 1).Equals(".")) {
+                Game newGame = new Game(gameDir.FullName);
+                games.Add(newGame);
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
- [x] read playlist title and description from `Playlists/playlist-name/winnitron_metadata.json` (if available)
- [x] On sync, write those metadata files like we do with games
- [x] use that for local playlists rather than the `_Title` hack