### PR TITLE
Logging fixes

### DIFF
--- a/Assets/Scenes/Launcher.unity
+++ b/Assets/Scenes/Launcher.unity
@@ -4031,7 +4031,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 267f9bb973d10493ab68be600e565a56, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  initialLogLevel: 3
+  initialLogLevel: 0
   globalOn: 0
   showNull: 0
   showTimestamps: 1

--- a/Assets/Scripts/System/GM/OptionsManager.cs
+++ b/Assets/Scripts/System/GM/OptionsManager.cs
@@ -149,6 +149,7 @@ public class OptionsManager : MonoBehaviour
         }
         else
         {
+            GM.Instance.logger.Error("Cannot find options file: " + optionsFile);
             GM.Instance.Oops(GM.Instance.Text("error", "cannotFindJson"), true);
         }
 


### PR DESCRIPTION
- log level `debug` from launch time until we load the options file to tell us otherwise
- this is handy if there's an issue loading said options file
