### PR TITLE
Fix Attract wonk

### DIFF
--- a/Assets/Scripts/System/Classes/AttractItem.cs
+++ b/Assets/Scripts/System/Classes/AttractItem.cs
@@ -9,7 +9,7 @@ using System.Linq;
 [System.Serializable]
 public class AttractItem {
 
-    public enum AttractItemType { Video, Image, Text }
+    public enum AttractItemType { None, Video, Image, Text }
     public AttractItemType type;
 
     public Sprite sprite;
@@ -17,8 +17,6 @@ public class AttractItem {
 
     public string pathToItem;
     public float displayTime = 10;
-
-    public bool voidItem = false;
 
     /// <summary>
     /// Constructs an AttractItem to be used later.
@@ -49,7 +47,7 @@ public class AttractItem {
         else
         {
             GM.Instance.logger.Debug("AttractItem - No valid file found.  Voiding file " + pathToItem);
-            voidItem = true;
+            type = AttractItemType.None;
         }
     }
 
@@ -66,10 +64,9 @@ public class AttractItem {
             // Turn the Texture2D into a sprite
             sprite = Sprite.Create(screenshotTex, new Rect(0, 0, screenshotTex.width, screenshotTex.height), new Vector2(0.5f, 0.5f));
         }
-
         else
         {
-            voidItem = true;
+            type = AttractItemType.None;
         }
     }
 
@@ -81,9 +78,10 @@ public class AttractItem {
             StreamReader reader = new StreamReader(pathToItem);
             text = reader.ReadToEnd();
         }
-
         else
-            voidItem = true;
+        {
+            type = AttractItemType.None;
+        }
     }
 
 }

--- a/Assets/Scripts/System/StateMachine/States/AttractState.cs
+++ b/Assets/Scripts/System/StateMachine/States/AttractState.cs
@@ -17,7 +17,7 @@ public class AttractState : State {
     {
         //Call the inherited functions to get the helper variable
         base.OnStateEnter(animator, info, layerIndex);
-        
+
         helper.attract.SetActive(true);
 
         numberOfItems = GM.Instance.data.attractItems.Count;
@@ -54,10 +54,9 @@ public class AttractState : State {
                 if (!GM.Instance.video.player.isPlaying)
                     ShowNextItem();
             }
-
-            //On text or image, just go to the next one
             else
             {
+                // On text or image, just go to the next one
                 ShowNextItem();
             }
         }
@@ -88,7 +87,6 @@ public class AttractState : State {
                     return;
             }
         }
-
         else
         {
             GM.Instance.logger.Debug("Attract: Item Number does not exist.");

--- a/Assets/Scripts/System/StateMachine/States/AttractState.cs
+++ b/Assets/Scripts/System/StateMachine/States/AttractState.cs
@@ -10,6 +10,8 @@ public class AttractState : State {
 
     public float displayTime;
 
+    private Vector3 imageStartPos;
+    private Vector3 textStartPos;
 
     //STATE BASE FUNCTIONS
 
@@ -110,6 +112,11 @@ public class AttractState : State {
         GM.Instance.video.PlayBackground();
 
         //Display the image
+        if (imageStartPos == null) {
+            imageStartPos = helper.attractImage.transform.position;
+        }
+
+        helper.attractImage.transform.position = imageStartPos;
         helper.attractImage.gameObject.SetActive(true);
         helper.attractImage.sprite = GetCurrentItem().sprite;
         displayTime = GetCurrentItem().displayTime;
@@ -134,7 +141,12 @@ public class AttractState : State {
         //Get the background goin'
         GM.Instance.video.PlayBackground();
 
+        if (textStartPos == null) {
+            textStartPos = helper.attractText.transform.position;
+        }
+
         //Play background video, and display text
+        helper.attractText.transform.position = textStartPos;
         helper.attractText.gameObject.SetActive(true);
         helper.attractText.text = GetCurrentItem().text;
         displayTime = GetCurrentItem().displayTime;


### PR DESCRIPTION
Two little bugs:

- It'd be possible to have an invalid file in the `Attract/` folder (I noticed in dev on my Mac because of course there's a hidden `.DS_Store` in there). That'd be fine, except it would be assigned the same type value as the previous item. e.g.:
  - first file is a video ✓
  - second file is something we can't handle X
  - but item type is still set to video, so it'd try and play
  - a hiccup while it errors and recovers (which is now solved)

- images and text items in `Attract/` would zoom in forever, because their position wouldn't reset when moving to the next item