### PR TITLE
Customizable AHK templates

### DIFF
--- a/Assets/Scripts/System/Classes/AhkBuilder.cs
+++ b/Assets/Scripts/System/Classes/AhkBuilder.cs
@@ -1,0 +1,164 @@
+using UnityEngine;
+using System.IO;
+using System.Collections;
+using SimpleJSON;
+
+class AhkBuilder {
+
+    private string template;
+    private string compiledAHK;
+    private Game game;
+
+    public AhkBuilder(Game game) {
+        this.game = game;
+        chooseTemplate();
+    }
+
+    public void compile() {
+        compiledAHK = template;
+
+        if (game.gameType == Game.GameType.PICO8) {
+            compiledAHK = Resources.Load<TextAsset>("AHK_templates/Pico8GameTemplate").text;
+            compiledAHK = compiledAHK.Replace("{GAME_PATH}", GM.Instance.options.dataPath + "/Options/Pico8/nw.exe");
+        } else {
+            compiledAHK = compiledAHK.Replace("{GAME_PATH}", game.executable);
+            compiledAHK = compiledAHK.Replace("{GAME_NAME}", game.name);
+        }
+
+        compiledAHK = compiledAHK.Replace("{GAME_FILE}", Path.GetFileName(game.executable));
+        compiledAHK = compiledAHK.Replace("{DEBUG_OUTPUT}", "true"); // TODO make this configurable
+        compiledAHK = compiledAHK.Replace("{IDLE_TIME}", "" + GM.Instance.options.runnerSecondsIdle);
+        compiledAHK = compiledAHK.Replace("{IDLE_INITIAL}", "" + GM.Instance.options.runnerSecondsIdleInitial);
+        compiledAHK = compiledAHK.Replace("{ESC_HOLD}", "" + GM.Instance.options.runnerSecondsESCHeld);
+
+        compiledAHK = insertKeyMapping(compiledAHK);
+    }
+
+    public void write() {
+        game.WriteStringToFile(compiledAHK, "RunGame.ahk");
+    }
+
+
+
+
+    private void chooseTemplate() {
+        switch (game.gameType) {
+
+            case Game.GameType.PICO8:
+                string newJS = Resources.Load<TextAsset>("Pico8Launcher").text;
+                newJS = newJS.Replace("{{{PATH_TO_HTML}}}", game.executable.Replace("\\", "\\\\"));
+                game.WriteStringToFile(newJS, "Pico8Launcher.js");
+                break;
+
+            case Game.GameType.FLASH:
+                template = Resources.Load<TextAsset>("AHK_templates/FlashGameTemplate").text;
+                break;
+
+            default:
+                template = Resources.Load<TextAsset>("AHK_templates/ExeGameTemplate").text;
+                break;
+        }
+    }
+
+    private string insertKeyMapping(string ahkFile) {
+        string keymap = "";
+        JSONNode parsedBindings = getKeyBindings();
+        ArrayList gameKeys = allGameKeys(parsedBindings);
+
+        // Write keys for players we have.
+        for(int pNum = 1; pNum <= game.savedMetadata["max_players"].AsInt; pNum++) {
+            JSONNode playerKeys;
+
+            try {
+                playerKeys = parsedBindings[pNum.ToString()];
+            } catch (System.NullReferenceException) {
+                break;
+            }
+
+            foreach(string control in KeyBindings.CONTROLS) {
+                KeyCode key = GM.Instance.options.keys.GetKey(pNum, control);
+                string launcherKey = GM.Instance.options.keyTranslator.toAHK(key);
+                string gameKey = playerKeys[control];
+
+                if (gameKey == null) { // this shouldn't happen, but just in case.
+                    gameKey = "return";
+                }
+
+                keymap += (launcherKey + "::" + gameKey + "\n");
+            }
+        }
+
+        // Write keys for players we don't have (e.g., players 3 & 4 on 2-player game)
+        for(int pNum = game.savedMetadata["max_players"].AsInt + 1; pNum <= 4; pNum++) {
+            foreach(string control in KeyBindings.CONTROLS) {
+                KeyCode key = GM.Instance.options.keys.GetKey(pNum, control);
+                string launcherKey = GM.Instance.options.keyTranslator.toAHK(key);
+
+                if (!gameKeys.Contains(launcherKey))
+                    keymap += (launcherKey + "::return\n");
+            }
+        }
+
+        return ahkFile.Replace("{KEYMAP}", keymap);
+    }
+
+    private ArrayList allGameKeys(JSONNode bindings) {
+        ArrayList keys = new ArrayList();
+
+        for(int pNum = 1; pNum <= 4; pNum++) {
+            foreach(string control in KeyBindings.CONTROLS) {
+                string key = bindings[pNum.ToString()][control];
+
+                if (key != null)
+                    keys.Add(key);
+            }
+        }
+
+        return keys;
+    }
+
+    private JSONNode getKeyBindings() {
+        string tmpl = game.savedMetadata["keys"]["template"];
+        JSONNode bindings = null;
+
+        string tmplFile = Path.Combine(GM.Instance.options.defaultOptionsPath, "keymap_templates.json");
+        JSONNode bindingTemplates = GM.Instance.data.LoadJson(tmplFile);
+
+        if (tmpl == null) {
+            if (game.savedMetadata["keys"]["bindings"] == null) {
+                GM.Instance.logger.Debug("No key binding info provided for " + game.name + ". Using defaults.");
+                tmpl = "default";
+            } else {
+                tmpl = "custom";
+            }
+        }
+
+        switch(tmpl) {
+            case "custom":
+                GM.Instance.logger.Debug("Loading custom key bindings for " + game.name);
+                bindings = game.savedMetadata["keys"]["bindings"];
+                break;
+
+            case "default":
+            case "legacy":
+            case "flash":
+            case "pico8":
+                GM.Instance.logger.Debug("Loading " + tmpl + " bindings from tmplFile: " + tmplFile);
+                bindings = bindingTemplates[tmpl];
+                break;
+
+            default:
+                GM.Instance.logger.Error("Invalid key template type '" + tmpl + "' for " + game.name + ". (Using default.) Valid templates are 'default', 'legacy', 'pico8', 'custom'.");
+                GM.Instance.logger.Debug("Loading " + tmpl + " bindings from tmplFile: " + tmplFile);
+                bindings = bindingTemplates["default"];
+                break;
+        }
+
+        // Remove controls for players that don't exist.
+        for (int p = game.savedMetadata["max_players"].AsInt + 1; p <= 4; p++) {
+            bindings.Remove(p.ToString());
+        }
+
+        return bindings;
+    }
+}

--- a/Assets/Scripts/System/Classes/AhkBuilder.cs
+++ b/Assets/Scripts/System/Classes/AhkBuilder.cs
@@ -51,12 +51,35 @@ class AhkBuilder {
                 break;
 
             case Game.GameType.FLASH:
-                template = Resources.Load<TextAsset>("AHK_templates/FlashGameTemplate").text;
+                template = loadTemplate("flash");
+
+                if (template == null)
+                    template = Resources.Load<TextAsset>("AHK_templates/FlashGameTemplate").text;
                 break;
 
             default:
-                template = Resources.Load<TextAsset>("AHK_templates/ExeGameTemplate").text;
+                template = loadTemplate("default");
+
+                if (template == null)
+                    template = Resources.Load<TextAsset>("AHK_templates/ExeGameTemplate").text;
                 break;
+        }
+    }
+
+    private string loadTemplate(string type) {
+        string filename = GM.Instance.options.O["ahk"][type];
+
+        if (filename == null)
+            return null;
+
+        try {
+            return File.ReadAllText(filename);
+        } catch(FileNotFoundException) {
+            GM.Instance.logger.Warn("Could not find AHK template file " + filename + ". Using default.");
+            return null;
+        } catch(DirectoryNotFoundException) {
+            GM.Instance.logger.Warn("Could not find AHK template file " + filename + ". Using default.");
+            return null;
         }
     }
 

--- a/Assets/Scripts/System/Classes/AhkBuilder.cs.meta
+++ b/Assets/Scripts/System/Classes/AhkBuilder.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 59209f458585f4c20a337cc10742a037
+timeCreated: 1532733152
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Classes/Game.cs
+++ b/Assets/Scripts/System/Classes/Game.cs
@@ -43,7 +43,7 @@ public class Game
 
     public bool voidGame = false;
 
-    private JSONNode savedMetadata;
+    public JSONNode savedMetadata;
 
     /// <summary>
     /// The game only takes in a directory handed down by the Playlist class, it then finds all the relevant information for the Game
@@ -182,14 +182,9 @@ public class Game
     private string findFirstImage(string ext) {
         try {
             return Directory.GetFiles(directory.FullName, "*." + ext)[0];
-        } catch (System.IndexOutOfRangeException e) {
+        } catch (System.IndexOutOfRangeException) {
             return null;
         }
-    }
-
-    private string GetExecutablePath() {
-        //Find the .exe in the directory and save a reference
-        return Path.Combine(directory.FullName, executable);
     }
 
     private string GetGameNameFromFolderName() {
@@ -233,52 +228,9 @@ public class Game
     /// and put them in the same folder as the game.
     /// </summary>
     public void BuildHelperScripts() {
-        GM.Instance.logger.Info("GAME: Create scripts for game " + name);
-
-        string newAHKfile = "";
-        string execFile = Path.GetFileName(executable);
-
-        switch (gameType) {
-
-            case Game.GameType.PICO8:
-
-                string newJS = Resources.Load<TextAsset>("Pico8Launcher").text;
-                newJS = newJS.Replace("{{{PATH_TO_HTML}}}", executable.Replace("\\", "\\\\"));
-                WriteStringToFile(newJS, "Pico8Launcher.js");
-
-                newAHKfile = Resources.Load<TextAsset>("AHK_templates/Pico8GameTemplate").text;
-                newAHKfile = newAHKfile.Replace("{GAME_PATH}", GM.Instance.options.dataPath + "/Options/Pico8/nw.exe");
-                break;
-
-            case Game.GameType.FLASH:
-
-                newAHKfile = Resources.Load<TextAsset>("AHK_templates/FlashGameTemplate").text;
-
-                newAHKfile = newAHKfile.Replace("{GAME_PATH}", executable);
-                newAHKfile = newAHKfile.Replace("{GAME_NAME}", name);
-                break;
-
-            default:
-                newAHKfile = Resources.Load<TextAsset>("AHK_templates/ExeGameTemplate").text;
-
-                newAHKfile = newAHKfile.Replace("{GAME_PATH}", executable);
-                newAHKfile = newAHKfile.Replace("{GAME_NAME}", name);
-                break;
-        }
-
-        //Things needed for every Launcher Script
-
-        //Replace variables
-        newAHKfile = newAHKfile.Replace("{GAME_FILE}", execFile);
-        newAHKfile = newAHKfile.Replace("{DEBUG_OUTPUT}", "true"); // TODO make this configurable
-        newAHKfile = newAHKfile.Replace("{IDLE_TIME}", "" + GM.Instance.options.runnerSecondsIdle);
-        newAHKfile = newAHKfile.Replace("{IDLE_INITIAL}", "" + GM.Instance.options.runnerSecondsIdleInitial);
-        newAHKfile = newAHKfile.Replace("{ESC_HOLD}", "" + GM.Instance.options.runnerSecondsESCHeld);
-
-        newAHKfile = insertKeyMapping(newAHKfile);
-
-        //Delete old file and write to new one
-        WriteStringToFile(newAHKfile, "RunGame.ahk");
+        AhkBuilder ahk = new AhkBuilder(this);
+        ahk.compile();
+        ahk.write();
     }
 
     /// <summary>
@@ -295,115 +247,12 @@ public class Game
         }
     }
 
-
-    private string insertKeyMapping(string ahkFile) {
-        string keymap = "";
-        JSONNode parsedBindings = getKeyBindings();
-        ArrayList gameKeys = allGameKeys(parsedBindings);
-
-        // Write keys for players we have.
-        for(int pNum = 1; pNum <= savedMetadata["max_players"].AsInt; pNum++) {
-            JSONNode playerKeys;
-
-            try {
-                playerKeys = parsedBindings[pNum.ToString()];
-            } catch (System.NullReferenceException) {
-                break;
-            }
-
-            foreach(string control in KeyBindings.CONTROLS) {
-                KeyCode key = GM.Instance.options.keys.GetKey(pNum, control);
-                string launcherKey = GM.Instance.options.keyTranslator.toAHK(key);
-                string gameKey = playerKeys[control];
-
-                if (gameKey == null) { // this shouldn't happen, but just in case.
-                    gameKey = "return";
-                }
-
-                keymap += (launcherKey + "::" + gameKey + "\n");
-            }
-        }
-
-        // Write keys for players we don't have (e.g., players 3 & 4 on 2-player game)
-        for(int pNum = savedMetadata["max_players"].AsInt + 1; pNum <= 4; pNum++) {
-            foreach(string control in KeyBindings.CONTROLS) {
-                KeyCode key = GM.Instance.options.keys.GetKey(pNum, control);
-                string launcherKey = GM.Instance.options.keyTranslator.toAHK(key);
-
-                if (!gameKeys.Contains(launcherKey))
-                    keymap += (launcherKey + "::return\n");
-            }
-        }
-
-        return ahkFile.Replace("{KEYMAP}", keymap);
-    }
-
-    private ArrayList allGameKeys(JSONNode bindings) {
-        ArrayList keys = new ArrayList();
-
-        for(int pNum = 1; pNum <= 4; pNum++) {
-            foreach(string control in KeyBindings.CONTROLS) {
-                string key = bindings[pNum.ToString()][control];
-
-                if (key != null)
-                    keys.Add(key);
-            }
-        }
-
-        return keys;
-    }
-
-    private JSONNode getKeyBindings() {
-        string tmpl = savedMetadata["keys"]["template"];
-        JSONNode bindings = null;
-
-        string tmplFile = Path.Combine(GM.Instance.options.defaultOptionsPath, "keymap_templates.json");
-        JSONNode bindingTemplates = GM.Instance.data.LoadJson(tmplFile);
-
-        if (tmpl == null) {
-            if (savedMetadata["keys"]["bindings"] == null) {
-                GM.Instance.logger.Debug("No key binding info provided for " + name + ". Using defaults.");
-                tmpl = "default";
-            } else {
-                tmpl = "custom";
-            }
-        }
-
-        switch(tmpl) {
-            case "custom":
-                GM.Instance.logger.Debug("Loading custom key bindings for " + name);
-                bindings = savedMetadata["keys"]["bindings"];
-                break;
-
-            case "default":
-            case "legacy":
-            case "flash":
-            case "pico8":
-                GM.Instance.logger.Debug("Loading " + tmpl + " bindings from tmplFile: " + tmplFile);
-                bindings = bindingTemplates[tmpl];
-                break;
-
-            default:
-                GM.Instance.logger.Error("Invalid key template type '" + tmpl + "' for " + name + ". (Using default.) Valid templates are 'default', 'legacy', 'pico8', 'custom'.");
-                GM.Instance.logger.Debug("Loading " + tmpl + " bindings from tmplFile: " + tmplFile);
-                bindings = bindingTemplates["default"];
-                break;
-        }
-
-        // Remove controls for players that don't exist.
-        for (int p = savedMetadata["max_players"].AsInt + 1; p <= 4; p++) {
-            bindings.Remove(p.ToString());
-        }
-
-        return bindings;
-    }
-
     /// <summary>
     /// Writes the text to the filename in the Game directory.
     /// </summary>
     /// <param name="text">The text to encode into the file.</param>
     /// <param name="fileName">The name of the file.</param>
-    private void WriteStringToFile(string text, string fileName) {
+    public void WriteStringToFile(string text, string fileName) {
         string behaviour = GM.Instance.options.O["launcher"]["writeScripts"];
         if (behaviour == null)
             behaviour = "always"; // backwards-compatible default behavior

--- a/Assets/Scripts/System/Classes/Game.cs
+++ b/Assets/Scripts/System/Classes/Game.cs
@@ -60,7 +60,9 @@ public class Game
             BuildGame();
         }
 
-        BuildHelperScripts();
+        AhkBuilder ahk = new AhkBuilder(this);
+        ahk.compile();
+        ahk.write();
     }
 
     /// <summary>
@@ -221,16 +223,6 @@ public class Game
         //Can't determine game type, voiding this game
         voidGame = true;
         return false;
-    }
-
-    /// <summary>
-    /// This will make the launcher AHK scripts, and/or other scripts (.html files in pico8 case)
-    /// and put them in the same folder as the game.
-    /// </summary>
-    public void BuildHelperScripts() {
-        AhkBuilder ahk = new AhkBuilder(this);
-        ahk.compile();
-        ahk.write();
     }
 
     /// <summary>


### PR DESCRIPTION
Not-so-theoretical situation: you want to tweak (or bugfix!) the AHK templates. [It's possible to do it manually per-game and then configure the Launcher not to overwrite your changes](https://github.com/winnitron/WinnitronLauncher/blob/678ab98a9762d863609ddfde79f58780b61fbb64/Assets/Scripts/System/Classes/Game.cs#L406-L428) (note to self: wait, is that even documented?), but that's at best a pain in the ass. The only other option, unfortunately, is making an actual change to the Launcher and requiring a whole new build/installation.

Better yet would be if you could supply your own template entirely. (Or more likely, take the default on, modify it slightly, and have those changes propagate across all your installed games.)

This diff is primarily a refactor that takes all the AHK template building out of `Game` and puts it into its own `AhkBuilder` class.