### PR TITLE
Set environment variables

### DIFF
--- a/Assets/Editor/PostBuildProcessor.cs
+++ b/Assets/Editor/PostBuildProcessor.cs
@@ -15,9 +15,14 @@ public class PostBuildProcessor
 
         // Copy a file from the project folder to the build folder, alongside the built game.
         FileUtil.CopyFileOrDirectory("Assets/Options", pathToBuiltProject + "/WINNITRON_data/Options");
-        FileUtil.CopyFileOrDirectory("Assets/Options/WINNITRON.bat", pathToBuiltProject + "/WINNITRON.bat");
 
-        //Delete META files
+        string bat_dest = pathToBuiltProject + "/WINNITRON.bat";
+        if (File.Exists(bat_dest))
+            File.Delete(bat_dest);
+
+        FileUtil.CopyFileOrDirectory("Assets/Options/WINNITRON.bat", bat_dest);
+
+        // Delete META files
         var dir = new DirectoryInfo(pathToBuiltProject);
 
         foreach (var file in dir.GetFiles("*.meta"))

--- a/Assets/Options/Defaults/Resources/winnitron_text_english.json
+++ b/Assets/Options/Defaults/Resources/winnitron_text_english.json
@@ -1,6 +1,6 @@
 {
   "error": {
-    "cannotFindJson" : "Hmm!  It seems that we couldn't load winnitron_options.json.  Please double check that it is in the winnitron_data folder.  If you can't find it, download it again from the Winnitron GitHub page.",
+    "cannotFindJson" : "Hmm!  It seems that we couldn't load winnitron_options.json.  Please double check that it is in the WINNITRON_UserData/Options/ folder, or wherever you specified in winnitron_userdata_path.json.  If you can't find it, download it again from the Winnitron GitHub page.",
     "cannotFindUserDataPathJson" : "Why can't we find the winnitron_userdata_path.json file?  That's not good.",
     "test" : "Congrats!  You've successfully tested the Oops screen. :)",
     "noAPIkey" : "You need an API key to sync!  Please get one from network.winnitron.com or change sync.type in winnitron_options.json to 'local' to skip syncing.",

--- a/Assets/Options/Defaults/winnitron_options.json
+++ b/Assets/Options/Defaults/winnitron_options.json
@@ -13,7 +13,7 @@
     "widescreen": "true",
     "language": "english",
     "idleTimeBeforeAttract": "20",
-	"scale": "1"
+    "scale": "1"
   },
   "runner": {
     "initialIdleTimeSeconds": "30",

--- a/Assets/Scripts/System/GM/GM.cs
+++ b/Assets/Scripts/System/GM/GM.cs
@@ -152,8 +152,14 @@ public class GM : Singleton<GM> {
 
 
     private string ArcadeID() {
-        // TODO: name in options || api key
-        return "winnitron-1000";
+        // TODO: If we have an API key, that means we could fetch all our machine data
+        // (name, slug, etc) from the Network.
+
+        string key = options.GetSyncSettings()["apiKey"];
+        if (key == "YOUR API KEY HERE")
+            key = "";
+
+        return key.Trim();
     }
 
     //*

--- a/Assets/Scripts/System/GM/GM.cs
+++ b/Assets/Scripts/System/GM/GM.cs
@@ -61,10 +61,10 @@ public class GM : Singleton<GM> {
 
     IEnumerator Initialize()
     {
-        Environment.SetEnvironmentVariable("WINNITRON_LAUNCHER_VERSION", versionNumber);
-        Environment.SetEnvironmentVariable("WINNITRON_IDENTIFIER", ArcadeID());
+        Environment.SetEnvironmentVariable("WINNITRON_LAUNCHER_VERSION", versionNumber, EnvironmentVariableTarget.User);
+        Environment.SetEnvironmentVariable("WINNITRON_IDENTIFIER", ArcadeID(), EnvironmentVariableTarget.User);
 
-        //Let's initialize stuff in order
+        // Let's initialize stuff in order
         // Options are already loaded via Start()
         InfoText("STARTING UP", "Loading Runner...");
         runner.Init();
@@ -84,7 +84,8 @@ public class GM : Singleton<GM> {
 
     void OnApplicationQuit()
     {
-        // File.Delete(PidFile());
+        Environment.SetEnvironmentVariable("WINNITRON_LAUNCHER_VERSION", null, EnvironmentVariableTarget.User);
+        Environment.SetEnvironmentVariable("WINNITRON_IDENTIFIER", null, EnvironmentVariableTarget.User);
     }
 
     /// <summary>

--- a/Assets/Scripts/System/GM/GM.cs
+++ b/Assets/Scripts/System/GM/GM.cs
@@ -39,6 +39,7 @@ public class GM : Singleton<GM> {
 
     void Start() {
         logger.Info("##### VERSION " + versionNumber + " #####");
+        SetWindowTitle();
         WriteProcessInfo();
     }
 
@@ -163,6 +164,10 @@ public class GM : Singleton<GM> {
     public static extern IntPtr FindWindow(System.String className, System.String windowName);
     [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
     public static extern long SetWindowLong(long hwnd, long nIndex, long dwNewLong);
+    [DllImport("user32.dll", EntryPoint = "SetWindowText")]
+    public static extern bool SetWindowText(System.IntPtr hwnd, System.String lpString);
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern System.IntPtr GetActiveWindow();
 
     public static void ResetScreen() {
         SetWindowLong(FindWindow(null, Application.productName).ToInt32(), -16L, 0x00800000L);
@@ -177,11 +182,13 @@ public class GM : Singleton<GM> {
         return Path.Combine(Path.Combine(drive, path), "winnitron.pid");
     }
 
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern System.IntPtr GetActiveWindow();
-
     public static System.IntPtr GetWindowHandle() {
       return GetActiveWindow();
+    }
+
+    private void SetWindowTitle() {
+        System.IntPtr window = GetWindowHandle();
+        SetWindowText(window, "WinnitronLauncher!");
     }
 
     #else
@@ -196,6 +203,10 @@ public class GM : Singleton<GM> {
 
     public static System.IntPtr GetWindowHandle() {
       return System.IntPtr.Zero;
+    }
+
+    private void SetWindowTitle() {
+        // NOOP
     }
 
     #endif

--- a/Assets/Scripts/System/GM/GM.cs
+++ b/Assets/Scripts/System/GM/GM.cs
@@ -63,8 +63,7 @@ public class GM : Singleton<GM> {
     IEnumerator Initialize()
     {
         //Let's initialize stuff in order
-        InfoText("STARTING UP", "Loading Options...");
-        options.Init();
+        // Options are already loaded via Start()
         InfoText("STARTING UP", "Loading Runner...");
         runner.Init();
         InfoText("STARTING UP", "Checking Sync...");

--- a/Assets/Scripts/System/GM/GM.cs
+++ b/Assets/Scripts/System/GM/GM.cs
@@ -38,10 +38,8 @@ public class GM : Singleton<GM> {
 
 
     void Start() {
-
-        //Get the version number and other bulljazz
-        logger.Info("#####  VERSION " + versionNumber + " #####");
-        writeProcessInfo();
+        logger.Info("##### VERSION " + versionNumber + " #####");
+        WriteProcessInfo();
     }
 
     /// <summary>
@@ -62,6 +60,9 @@ public class GM : Singleton<GM> {
 
     IEnumerator Initialize()
     {
+        Environment.SetEnvironmentVariable("WINNITRON_LAUNCHER_VERSION", versionNumber);
+        Environment.SetEnvironmentVariable("WINNITRON_IDENTIFIER", ArcadeID());
+
         //Let's initialize stuff in order
         // Options are already loaded via Start()
         InfoText("STARTING UP", "Loading Runner...");
@@ -136,7 +137,7 @@ public class GM : Singleton<GM> {
         ResetScreen();
     }
 
-    private void writeProcessInfo() {
+    private void WriteProcessInfo() {
         string info = System.Diagnostics.Process.GetCurrentProcess().Id +
                       "\n" +
                       Path.Combine(Path.GetFullPath("."), "WINNITRON.bat") +
@@ -147,6 +148,11 @@ public class GM : Singleton<GM> {
         File.WriteAllText(PidFile(), info);
     }
 
+
+    private string ArcadeID() {
+        // TODO: name in options || api key
+        return "winnitron-1000";
+    }
 
     //*
     #if UNITY_STANDALONE_WIN

--- a/Assets/Scripts/System/GM/OptionsManager.cs
+++ b/Assets/Scripts/System/GM/OptionsManager.cs
@@ -25,9 +25,6 @@ public class OptionsManager : MonoBehaviour
     public string musicPath = "/Music";
     public string attractPath = "/Attract";
 
-    //Utilities
-    //public string legacyControlsPath = "/Util/WinnitronLegacy.exe";
-
     //Runner Settings
     public int runnerSecondsIdle = 10;
     public int runnerSecondsESCHeld = 3;
@@ -37,20 +34,13 @@ public class OptionsManager : MonoBehaviour
     public KeyBindings keys;
     public KeyTranslator keyTranslator;
 
-    //language
-    public JSONNode language;
-
-    //Sync Settings
-    public JSONNode sync;
-
-    public JSONNode logger;
-
-    //Options JSON
+    // Parsed winnitron_options.json
     public JSONNode O;
 
-    // Use this for initialization
-    public void Init()
-    {
+    public JSONNode language;
+    public JSONNode logger;
+
+    public void Start() {
         // we need to load default language here, so we can display errors
         language = GM.Instance.data.GetDefautLanguage();
         defaultOptionsPath = Path.Combine(Application.dataPath, "Options");
@@ -164,7 +154,13 @@ public class OptionsManager : MonoBehaviour
 
     public JSONNode GetSyncSettings()
     {
-        return O["sync"];
+        if (O == null) {
+            GM.Instance.logger.Error("Trying to access options before they've been loaded.");
+            return null;
+        } else {
+            return O["sync"];
+        }
+
     }
 
     private string InitDataFolder(string jsonKey)

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,16 +3,17 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 14
+  serializedVersion: 15
   productGUID: 829acd0741c324f4680d669c0e5c8593
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
+  AndroidEnableSustainedPerformanceMode: 0
   defaultScreenOrientation: 4
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: Winnitron
-  productName: WinnitronLauncher!
+  productName: WINNITRON
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -51,7 +52,6 @@ PlayerSettings:
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
-  tizenShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
   displayResolutionDialog: 0
   iosAllowHTTPDownload: 1
@@ -64,7 +64,6 @@ PlayerSettings:
   preserveFramebufferAlpha: 0
   disableDepthAndStencilBuffers: 0
   androidBlitType: 0
-  defaultIsFullScreen: 0
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 0
@@ -91,8 +90,7 @@ PlayerSettings:
   visibleInBackground: 0
   allowFullscreenSwitch: 0
   graphicsJobMode: 0
-  macFullscreenMode: 2
-  d3d11FullscreenMode: 1
+  fullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -108,18 +106,12 @@ PlayerSettings:
   xboxOneLoggingLevel: 1
   xboxOneDisableEsram: 0
   xboxOnePresentImmediateThreshold: 0
+  switchQueueCommandMemory: 0
   videoMemoryForVertexBuffers: 0
   psp2PowerMode: 0
   psp2AcquireBGM: 1
-  wiiUTVResolution: 0
-  wiiUGamePadMSAA: 1
-  wiiUSupportsNunchuk: 0
-  wiiUSupportsClassicController: 0
-  wiiUSupportsBalanceBoard: 0
-  wiiUSupportsMotionPlus: 0
-  wiiUSupportsProController: 0
-  wiiUAllowScreenCapture: 1
-  wiiUControllerCount: 0
+  vulkanEnableSetSRGBWrite: 0
+  vulkanUseSWCommandBuffers: 0
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 0
@@ -150,6 +142,7 @@ PlayerSettings:
     oculus:
       sharedDepthBuffer: 0
       dashSupport: 0
+    enable360StereoCapture: 0
   protectGraphicsMemory: 0
   useHDRDisplay: 0
   m_ColorGamuts: 00000000
@@ -179,11 +172,9 @@ PlayerSettings:
   APKExpansionFiles: 0
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
-  VertexChannelCompressionMask:
-    serializedVersion: 2
-    m_Bits: 238
+  VertexChannelCompressionMask: 214
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 7.0
+  iOSTargetOSVersionString: 8.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 9.0
@@ -244,13 +235,21 @@ PlayerSettings:
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
+  iOSManualSigningProvisioningProfileType: 0
+  tvOSManualSigningProvisioningProfileType: 0
   appleEnableAutomaticSigning: 0
+  iOSRequireARKit: 0
+  appleEnableProMotion: 0
+  vulkanEditorSupport: 0
   clonedFromGUID: 00000000000000000000000000000000
-  AndroidTargetDevice: 0
+  templatePackageId: 
+  templateDefaultScene: 
+  AndroidTargetArchitectures: 5
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
   AndroidKeyaliasName: 
+  AndroidBuildApkPerCpuArchitecture: 0
   AndroidTVCompatibility: 1
   AndroidIsGame: 1
   AndroidEnableTango: 0
@@ -307,6 +306,7 @@ PlayerSettings:
       m_Width: 16
       m_Height: 16
       m_Kind: 0
+  m_BuildTargetPlatformIcons: []
   m_BuildTargetBatching: []
   m_BuildTargetGraphicsAPIs: []
   m_BuildTargetVRSettings:
@@ -379,25 +379,9 @@ PlayerSettings:
     m_EncodingQuality: 1
   - m_BuildTarget: PS4
     m_EncodingQuality: 1
-  wiiUTitleID: 0005000011000000
-  wiiUGroupID: 00010000
-  wiiUCommonSaveSize: 4096
-  wiiUAccountSaveSize: 2048
-  wiiUOlvAccessKey: 0
-  wiiUTinCode: 0
-  wiiUJoinGameId: 0
-  wiiUJoinGameModeMask: 0000000000000000
-  wiiUCommonBossSize: 0
-  wiiUAccountBossSize: 0
-  wiiUAddOnUniqueIDs: []
-  wiiUMainThreadStackSize: 3072
-  wiiULoaderThreadStackSize: 1024
-  wiiUSystemHeapSize: 128
-  wiiUTVStartupScreen: {fileID: 0}
-  wiiUGamePadStartupScreen: {fileID: 0}
-  wiiUDrcBufferDisabled: 0
-  wiiUProfilerLibPath: 
+  m_BuildTargetGroupLightmapSettings: []
   playModeTestRunnerEnabled: 0
+  runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
@@ -518,6 +502,9 @@ PlayerSettings:
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
   switchSupportedNpadStyles: 3
+  switchNativeFsCacheSize: 32
+  switchIsHoldTypeHorizontal: 0
+  switchSupportedNpadCount: 8
   switchSocketConfigEnabled: 0
   switchTcpInitialSendBufferSize: 32
   switchTcpInitialReceiveBufferSize: 64
@@ -573,6 +560,7 @@ PlayerSettings:
   ps4pnFriends: 1
   ps4pnGameCustomData: 1
   playerPrefsSupport: 0
+  enableApplicationExit: 0
   restrictedAudioUsageRights: 0
   ps4UseResolutionFallback: 0
   ps4ReprojectionSupport: 0
@@ -643,7 +631,6 @@ PlayerSettings:
   psp2InfoBarOnStartup: 0
   psp2InfoBarColor: 0
   psp2ScriptOptimizationLevel: 0
-  psmSplashimage: {fileID: 0}
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
   spritePackerPolicy: 
@@ -657,15 +644,17 @@ PlayerSettings:
   webGLTemplate: APPLICATION:Default
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
-  webGLUseWasm: 0
   webGLCompressionFormat: 1
+  webGLLinkerTarget: 1
   scriptingDefineSymbols: {}
   platformArchitecture: {}
   scriptingBackend:
     Standalone: 0
     WebGL: 1
     WebPlayer: 0
+  il2cppCompilerConfiguration: {}
   incrementalIl2cppBuild: {}
+  allowUnsafeCode: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 0
   apiCompatibilityLevelPerPlatform: {}
@@ -681,7 +670,6 @@ PlayerSettings:
   metroApplicationDescription: WinnitronLauncher!
   wsaImages: {}
   metroTileShortName: 
-  metroCommandLineArgsFile: 
   metroTileShowName: 0
   metroMediumTileShowName: 0
   metroLargeTileShowName: 0
@@ -697,14 +685,6 @@ PlayerSettings:
   metroFTAFileTypes: []
   metroProtocolName: 
   metroCompilationOverrides: 1
-  tizenProductDescription: 
-  tizenProductURL: 
-  tizenSigningProfileName: 
-  tizenGPSPermissions: 0
-  tizenMicrophonePermissions: 0
-  tizenDeploymentTarget: 
-  tizenDeploymentTargetType: -387588100
-  tizenMinOSVersion: 1
   n3dsUseExtSaveData: 0
   n3dsCompressStaticMem: 1
   n3dsExtSaveDataNumber: 0x12345
@@ -725,6 +705,7 @@ PlayerSettings:
   XboxOneGameOsOverridePath: 
   XboxOnePackagingOverridePath: 
   XboxOneAppManifestOverridePath: 
+  XboxOneVersion: 1.0.0.0
   XboxOnePackageEncryption: 0
   XboxOnePackageUpdateGranularity: 2
   XboxOneDescription: 
@@ -738,6 +719,7 @@ PlayerSettings:
   XboxOneSplashScreen: {fileID: 0}
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
+  XboxOneXTitleMemory: 8
   xboxOneScriptCompiler: 0
   vrEditorSettings:
     daydream:

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.2.6f1
+m_EditorVersion: 2018.2.7f1

--- a/ProjectSettings/UnityConnectSettings.asset
+++ b/ProjectSettings/UnityConnectSettings.asset
@@ -3,12 +3,14 @@
 --- !u!310 &1
 UnityConnectSettings:
   m_ObjectHideFlags: 0
-  m_Enabled: 0
+  m_Enabled: 1
   m_TestMode: 0
   m_TestEventUrl: 
   m_TestConfigUrl: 
+  m_TestInitMode: 0
   CrashReportingSettings:
     m_EventUrl: https://perf-events.cloud.unity3d.com/api/events/crashes
+    m_NativeEventUrl: https://perf-events.cloud.unity3d.com/symbolicate
     m_Enabled: 0
     m_CaptureEditorExceptions: 1
   UnityPurchasingSettings:
@@ -24,6 +26,9 @@ UnityConnectSettings:
     m_Enabled: 0
     m_InitializeOnStartup: 1
     m_TestMode: 0
-    m_EnabledPlatforms: 4294967295
     m_IosGameId: 
     m_AndroidGameId: 
+    m_GameIds: {}
+    m_GameId: 
+  PerformanceReportingSettings:
+    m_Enabled: 0


### PR DESCRIPTION
It may be useful for a game to know a) if it's running on a Winnitron, b) which Winnitron it's running on, and c) what version of the Launcher is installed.

On startup, Launcher sets `WINNITRON_VERSION` and `WINNITRON_IDENTIFIER` user environment variables.

I also squeezed in a bugfix here where sometimes we'd be trying to access options before they'd been loaded, which threw an exception and prevented the error/oops screen. 🙄 
